### PR TITLE
feat: WebSocket server for remote pi agent access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           xcodebuild build \
             -project apps/desktop/pi-desktop.xcodeproj \
-            -scheme Pi \
+            -scheme "Pi Desktop" \
             -configuration Debug \
             -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY="-" \
@@ -64,7 +64,7 @@ jobs:
         run: |
           xcodebuild build \
             -project apps/mobile/pi-mobile.xcodeproj \
-            -scheme Pi \
+            -scheme "Pi Mobile" \
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
             CODE_SIGN_IDENTITY="-" \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ XCODEGEN := xcodegen
 # Project
 WORKSPACE := PiApps.xcworkspace
 DESKTOP_PROJECT := apps/desktop/pi-desktop.xcodeproj
-DESKTOP_SCHEME := Pi
+DESKTOP_SCHEME := Pi Desktop
 
 # Default target
 all: build
@@ -47,7 +47,7 @@ generate:
 build: generate
 	@echo "==> Building Pi (Debug)..."
 	@xcodebuild -project $(DESKTOP_PROJECT) \
-		-scheme $(DESKTOP_SCHEME) \
+		-scheme "$(DESKTOP_SCHEME)" \
 		-configuration Debug \
 		build \
 		| grep -E "^(Build|Compile|Link|error:|warning:)" || true
@@ -55,7 +55,7 @@ build: generate
 build-release: generate
 	@echo "==> Building Pi (Release)..."
 	@xcodebuild -project $(DESKTOP_PROJECT) \
-		-scheme $(DESKTOP_SCHEME) \
+		-scheme "$(DESKTOP_SCHEME)" \
 		-configuration Release \
 		build \
 		| grep -E "^(Build|Compile|Link|error:|warning:)" || true
@@ -67,7 +67,7 @@ build-release: generate
 test: generate
 	@echo "==> Running tests..."
 	@xcodebuild -project $(DESKTOP_PROJECT) \
-		-scheme $(DESKTOP_SCHEME) \
+		-scheme "$(DESKTOP_SCHEME)" \
 		-configuration Debug \
 		test \
 		| grep -E "^(Test|Executed|error:|warning:|\\*\\*)" || true

--- a/apps/mobile/Sources/ContentView.swift
+++ b/apps/mobile/Sources/ContentView.swift
@@ -1,26 +1,16 @@
+//
+//  ContentView.swift
+//  Pi
+//
+//  Root content view
+//
+
 import SwiftUI
 import PiCore
 
 struct ContentView: View {
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 20) {
-                Image("PiLogo")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 60, height: 60)
-                    .foregroundStyle(Theme.accent)
-
-                Text("Pi")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-
-                Text("iOS app coming soon")
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Theme.pageBg)
-        }
+        MainView()
     }
 }
 

--- a/apps/mobile/Sources/Services/RPCClient.swift
+++ b/apps/mobile/Sources/Services/RPCClient.swift
@@ -1,0 +1,503 @@
+//
+//  RPCClient.swift
+//  pi-mobile
+//
+//  RPC client using WebSocketTransport from PiCore for iOS
+//
+
+import Foundation
+import PiCore
+
+// MARK: - Server-specific Types
+
+/// Information about a repository
+public struct RepoInfo: Decodable, Sendable {
+    public let id: String
+    public let name: String
+    public let path: String
+}
+
+/// Result from listing repositories
+public struct ReposListResult: Decodable, Sendable {
+    public let repos: [RepoInfo]
+}
+
+/// Result from creating a session
+public struct SessionCreateResult: Decodable, Sendable {
+    public let sessionId: String
+}
+
+/// Result from listing sessions
+public struct SessionListResult: Decodable, Sendable {
+    public let sessions: [SessionInfoResult]
+}
+
+/// Information about a session
+public struct SessionInfoResult: Decodable, Sendable, Identifiable {
+    public let sessionId: String
+    public let repoId: String
+    public let createdAt: String?
+    public let lastActivityAt: String?
+
+    public var id: String { sessionId }
+}
+
+// MARK: - RPC Client Errors
+
+public enum RPCClientError: Error, LocalizedError, Sendable {
+    case notRunning
+    case notConnected
+    case encodingFailed
+    case decodingFailed(String)
+    case requestTimeout
+    case requestCancelled
+    case invalidResponse(String)
+    case serverError(RPCError)
+    case connectionLost(String)
+    case alreadyConnected
+    case invalidServerURL
+    case transportError(RPCTransportError)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notRunning:
+            return "RPC client is not running"
+        case .notConnected:
+            return "Not connected to server"
+        case .encodingFailed:
+            return "Failed to encode command"
+        case .decodingFailed(let details):
+            return "Failed to decode response: \(details)"
+        case .requestTimeout:
+            return "Request timed out"
+        case .requestCancelled:
+            return "Request was cancelled"
+        case .invalidResponse(let details):
+            return "Invalid response: \(details)"
+        case .serverError(let error):
+            return error.message
+        case .connectionLost(let reason):
+            return "Connection lost: \(reason)"
+        case .alreadyConnected:
+            return "RPC client is already connected"
+        case .invalidServerURL:
+            return "Invalid server URL"
+        case .transportError(let error):
+            return error.localizedDescription
+        }
+    }
+
+    /// Create from transport error
+    public static func from(_ error: RPCTransportError) -> Self {
+        switch error {
+        case .notConnected:
+            return .notConnected
+        case .connectionFailed(let reason):
+            return .connectionLost(reason)
+        case .connectionLost(let reason):
+            return .connectionLost(reason)
+        case .encodingFailed:
+            return .encodingFailed
+        case .decodingFailed(let details):
+            return .decodingFailed(details)
+        case .timeout:
+            return .requestTimeout
+        case .cancelled:
+            return .requestCancelled
+        case .invalidResponse(let details):
+            return .invalidResponse(details)
+        case .serverError(let rpcError):
+            return .serverError(rpcError)
+        }
+    }
+}
+
+// MARK: - RPC Client Actor
+
+/// Actor-based RPC client that uses WebSocketTransport from PiCore
+public actor RPCClient {
+    // MARK: - Properties
+
+    private var transport: WebSocketTransport?
+    private var eventTask: Task<Void, Never>?
+
+    private var eventsContinuation: AsyncStream<RPCEvent>.Continuation?
+    private var _events: AsyncStream<RPCEvent>?
+
+    private var _isConnected = false
+
+    private let serverURL: URL
+    private let clientInfo: ClientInfo
+
+    /// The currently attached session ID
+    private var _currentSessionId: String?
+
+    // MARK: - Initialization
+
+    /// Initialize with a server URL
+    /// - Parameters:
+    ///   - serverURL: The WebSocket server URL
+    ///   - clientName: Name to identify this client (default: "pi-mobile")
+    ///   - clientVersion: Client version (default: "1.0")
+    public init(
+        serverURL: URL,
+        clientName: String = "pi-mobile",
+        clientVersion: String = "1.0"
+    ) {
+        self.serverURL = serverURL
+        self.clientInfo = ClientInfo(name: clientName, version: clientVersion)
+    }
+
+    deinit {
+        eventTask?.cancel()
+    }
+
+    // MARK: - Public Interface
+
+    /// Stream of events from the RPC server
+    public var events: AsyncStream<RPCEvent> {
+        get async {
+            if let existing = _events {
+                return existing
+            }
+
+            let (stream, continuation) = AsyncStream<RPCEvent>.makeStream(
+                bufferingPolicy: .bufferingNewest(100)
+            )
+            self.eventsContinuation = continuation
+            self._events = stream
+            return stream
+        }
+    }
+
+    /// Whether the client is currently connected
+    public var isConnected: Bool {
+        _isConnected
+    }
+
+    /// The currently attached session ID
+    public var currentSessionId: String? {
+        _currentSessionId
+    }
+
+    /// Connect to the WebSocket server
+    public func connect() async throws {
+        guard !_isConnected else {
+            throw RPCClientError.alreadyConnected
+        }
+
+        print("[RPCClient] Connecting to \(serverURL)")
+        let config = RPCTransportConfig.remote(url: serverURL, clientInfo: clientInfo)
+        let newTransport = WebSocketTransport(config: config)
+        transport = newTransport
+
+        do {
+            print("[RPCClient] Calling transport.connect()...")
+            try await newTransport.connect()
+            _isConnected = await newTransport.isConnected
+            print("[RPCClient] Transport connected: \(_isConnected)")
+
+            if !_isConnected {
+                transport = nil
+                throw RPCClientError.notConnected
+            }
+
+            // Start forwarding events from transport to our event stream
+            startEventForwarding()
+            print("[RPCClient] Connection established")
+
+        } catch let error as RPCTransportError {
+            print("[RPCClient] Transport error: \(error)")
+            transport = nil
+            _isConnected = false
+            throw RPCClientError.from(error)
+        } catch {
+            print("[RPCClient] Other error: \(error)")
+            throw error
+        }
+    }
+
+    /// Disconnect from the server
+    public func disconnect() async {
+        guard _isConnected else { return }
+
+        _isConnected = false
+        _currentSessionId = nil
+        eventTask?.cancel()
+        eventTask = nil
+
+        if let t = transport {
+            await t.disconnect()
+        }
+        transport = nil
+
+        // End event stream
+        eventsContinuation?.finish()
+        _events = nil
+        eventsContinuation = nil
+    }
+
+    // MARK: - Generic Send Methods
+
+    /// Send a request and wait for typed response
+    public func send<R: Decodable & Sendable>(
+        method: String,
+        sessionId: String? = nil,
+        params: (any Encodable & Sendable)? = nil
+    ) async throws -> R {
+        guard _isConnected, let transport else {
+            throw RPCClientError.notConnected
+        }
+
+        do {
+            return try await transport.send(
+                method: method,
+                sessionId: sessionId ?? _currentSessionId,
+                params: params
+            )
+        } catch let error as RPCTransportError {
+            let stillConnected = await transport.isConnected
+            if !stillConnected {
+                _isConnected = false
+            }
+            throw RPCClientError.from(error)
+        }
+    }
+
+    /// Send a request that returns no data (void response)
+    public func sendVoid(
+        method: String,
+        sessionId: String? = nil,
+        params: (any Encodable & Sendable)? = nil
+    ) async throws {
+        guard _isConnected, let transport else {
+            throw RPCClientError.notConnected
+        }
+
+        do {
+            try await transport.sendVoid(
+                method: method,
+                sessionId: sessionId ?? _currentSessionId,
+                params: params
+            )
+        } catch let error as RPCTransportError {
+            let stillConnected = await transport.isConnected
+            if !stillConnected {
+                _isConnected = false
+            }
+            throw RPCClientError.from(error)
+        }
+    }
+
+    /// Send a command and wait for response (legacy command interface)
+    public func send<C: RPCCommand, R: Decodable & Sendable>(_ command: C) async throws -> R {
+        try await send(method: command.type, params: command)
+    }
+
+    /// Send a command that returns no data (legacy command interface)
+    public func send<C: RPCCommand>(_ command: C) async throws {
+        try await sendVoid(method: command.type, params: command)
+    }
+
+    // MARK: - Server-specific Operations
+
+    /// List all available repositories
+    public func listRepos() async throws -> [RepoInfo] {
+        let result: ReposListResult = try await send(method: "repos.list")
+        return result.repos
+    }
+
+    /// Create a new session for a repository
+    /// - Parameter repoId: The repository ID to create a session for
+    /// - Returns: The created session info
+    public func createSession(repoId: String) async throws -> SessionCreateResult {
+        struct CreateSessionParams: Encodable, Sendable {
+            let repoId: String
+        }
+
+        return try await send(
+            method: "session.create",
+            params: CreateSessionParams(repoId: repoId)
+        )
+    }
+
+    /// List all sessions (optionally filtered by repo)
+    /// - Parameter repoId: Optional repository ID to filter sessions
+    /// - Returns: List of sessions
+    public func listSessions(repoId: String? = nil) async throws -> [SessionInfoResult] {
+        struct ListSessionsParams: Encodable, Sendable {
+            let repoId: String?
+        }
+
+        let result: SessionListResult = try await send(
+            method: "session.list",
+            params: repoId != nil ? ListSessionsParams(repoId: repoId) : nil
+        )
+        return result.sessions
+    }
+
+    /// Attach to an existing session
+    /// - Parameter sessionId: The session ID to attach to
+    public func attachSession(sessionId: String) async throws {
+        struct AttachSessionParams: Encodable, Sendable {
+            let sessionId: String
+        }
+
+        try await sendVoid(
+            method: "session.attach",
+            params: AttachSessionParams(sessionId: sessionId)
+        )
+
+        _currentSessionId = sessionId
+    }
+
+    /// Detach from the current session
+    public func detachSession() async throws {
+        guard _currentSessionId != nil else { return }
+
+        try await sendVoid(method: "session.detach")
+        _currentSessionId = nil
+    }
+
+    /// Delete a session
+    /// - Parameter sessionId: The session ID to delete
+    public func deleteSession(sessionId: String) async throws {
+        struct DeleteSessionParams: Encodable, Sendable {
+            let sessionId: String
+        }
+
+        try await sendVoid(
+            method: "session.delete",
+            params: DeleteSessionParams(sessionId: sessionId)
+        )
+
+        // If we deleted the current session, clear it
+        if _currentSessionId == sessionId {
+            _currentSessionId = nil
+        }
+    }
+
+    // MARK: - Agent Operations
+
+    /// Send a prompt to the agent
+    /// - Parameter message: The message to send
+    public func prompt(_ message: String) async throws {
+        let command = PromptCommand(message: message)
+        try await send(command) as Void
+    }
+
+    /// Abort ongoing operation
+    public func abort() async throws {
+        let command = AbortCommand()
+        try await send(command) as Void
+    }
+
+    /// Get current state
+    public func getState() async throws -> GetStateResponse {
+        let command = GetStateCommand()
+        return try await send(command)
+    }
+
+    /// Get available models
+    public func getAvailableModels() async throws -> GetAvailableModelsResponse {
+        let command = GetAvailableModelsCommand()
+        return try await send(command)
+    }
+
+    /// Set the active model
+    /// - Parameters:
+    ///   - provider: The model provider
+    ///   - modelId: The model ID
+    public func setModel(provider: String, modelId: String) async throws {
+        let command = SetModelCommand(provider: provider, modelId: modelId)
+        try await send(command) as Void
+    }
+
+    /// Get conversation history
+    public func getMessages() async throws -> GetMessagesResponse {
+        let command = GetMessagesCommand()
+        return try await send(command)
+    }
+
+    /// Clear conversation
+    public func clearConversation() async throws {
+        let command = ClearConversationCommand()
+        try await send(command) as Void
+    }
+
+    // MARK: - Private Methods
+
+    private func startEventForwarding() {
+        guard let transport else { return }
+
+        // Ensure event stream exists before starting to forward
+        // This creates the continuation that forwardEvent will use
+        if _events == nil {
+            let (stream, continuation) = AsyncStream<RPCEvent>.makeStream(
+                bufferingPolicy: .bufferingNewest(100)
+            )
+            self.eventsContinuation = continuation
+            self._events = stream
+        }
+
+        eventTask = Task { [weak self] in
+            let eventStream = await transport.events
+
+            for await transportEvent in eventStream {
+                guard let self, !Task.isCancelled else { break }
+
+                // Forward the event (TransportEvent contains RPCEvent)
+                await self.forwardEvent(transportEvent.event)
+            }
+
+            // Transport event stream ended - mark as not connected
+            if let self {
+                await self.handleTransportDisconnect()
+            }
+        }
+    }
+
+    private func forwardEvent(_ event: RPCEvent) {
+        eventsContinuation?.yield(event)
+    }
+
+    private func handleTransportDisconnect() {
+        guard _isConnected else { return }
+
+        _isConnected = false
+
+        // Signal end with an error event
+        eventsContinuation?.yield(.agentEnd(
+            success: false,
+            error: RPCError(
+                code: "transport_disconnect",
+                message: "WebSocket connection lost",
+                details: nil
+            )
+        ))
+        eventsContinuation?.finish()
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension RPCClient {
+    /// Create a client from ServerConfig
+    /// Note: Internal access level since ServerConfig is internal
+    /// Note: MainActor since ServerConfig is MainActor-isolated
+    @MainActor
+    static func fromConfig(_ config: ServerConfig) -> RPCClient? {
+        guard let url = config.serverURL else {
+            return nil
+        }
+        return RPCClient(serverURL: url)
+    }
+
+    /// Create a client with a URL string
+    nonisolated public static func withURL(_ urlString: String) -> RPCClient? {
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+        return RPCClient(serverURL: url)
+    }
+}

--- a/apps/mobile/Sources/Services/ServerConfig.swift
+++ b/apps/mobile/Sources/Services/ServerConfig.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Manages server connection configuration
+@MainActor
+class ServerConfig: ObservableObject {
+    static let shared = ServerConfig()
+
+    private let urlKey = "pi_server_url"
+
+    @Published var serverURL: URL?
+
+    private init() {
+        let urlString = UserDefaults.standard.string(forKey: urlKey)
+        print("[ServerConfig] init - urlKey=\(urlKey), urlString=\(urlString ?? "nil")")
+        if let urlString, let url = URL(string: urlString) {
+            self.serverURL = url
+            print("[ServerConfig] URL configured: \(url)")
+        } else {
+            print("[ServerConfig] No URL configured")
+        }
+    }
+
+    func setServerURL(_ url: URL) {
+        serverURL = url
+        UserDefaults.standard.set(url.absoluteString, forKey: urlKey)
+    }
+
+    func clearServerURL() {
+        serverURL = nil
+        UserDefaults.standard.removeObject(forKey: urlKey)
+    }
+
+    var isConfigured: Bool {
+        serverURL != nil
+    }
+}

--- a/apps/mobile/Sources/Views/ConversationView.swift
+++ b/apps/mobile/Sources/Views/ConversationView.swift
@@ -1,0 +1,654 @@
+//
+//  ConversationView.swift
+//  pi-mobile
+//
+//  Chat interface for conversing with the AI agent
+//
+
+import SwiftUI
+import PiCore
+
+// MARK: - Conversation Item
+
+enum ConversationItem: Identifiable {
+    case userMessage(id: String, text: String)
+    case assistantText(id: String, text: String)
+    case toolCall(id: String, name: String, args: String?, output: String?, status: ToolCallStatus)
+
+    var id: String {
+        switch self {
+        case .userMessage(let id, _): return id
+        case .assistantText(let id, _): return id
+        case .toolCall(let id, _, _, _, _): return id
+        }
+    }
+}
+
+// MARK: - ConversationView
+
+struct ConversationView: View {
+    let client: RPCClient
+    let sessionId: String
+    let onDisconnect: () -> Void
+
+    @State private var items: [ConversationItem] = []
+    @State private var inputText = ""
+    @State private var isProcessing = false
+    @State private var expandedToolCalls: Set<String> = []
+    @State private var currentStreamingText = ""
+    @State private var currentStreamingId: String?
+    @State private var eventTask: Task<Void, Never>?
+    @State private var errorMessage: String?
+    @State private var showError = false
+
+    @FocusState private var isInputFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Messages list
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(items) { item in
+                            itemView(item)
+                                .id(item.id)
+                        }
+
+                        // Show streaming text
+                        if !currentStreamingText.isEmpty, let streamId = currentStreamingId {
+                            assistantBubble(currentStreamingText)
+                                .id(streamId)
+                        }
+
+                        // Processing indicator
+                        if isProcessing && currentStreamingText.isEmpty {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                                Text("Thinking...")
+                                    .font(.subheadline)
+                                    .foregroundColor(Theme.muted)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 16)
+                            .id("processing")
+                        }
+
+                        Color.clear
+                            .frame(height: 1)
+                            .id("bottom")
+                    }
+                    .padding(.vertical, 12)
+                }
+                .onChange(of: items.count) { _, _ in
+                    scrollToBottom(proxy)
+                }
+                .onChange(of: currentStreamingText) { _, _ in
+                    scrollToBottom(proxy)
+                }
+            }
+
+            Divider()
+                .background(Theme.borderMuted)
+
+            // Input area
+            inputArea
+        }
+        .background(Theme.pageBg)
+        .navigationTitle("Chat")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu {
+                    Button(role: .destructive) {
+                        Task { await clearConversation() }
+                    } label: {
+                        Label("Clear Chat", systemImage: "trash")
+                    }
+
+                    Button {
+                        onDisconnect()
+                    } label: {
+                        Label("Disconnect", systemImage: "xmark.circle")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "An error occurred")
+        }
+        .task {
+            // Attach to session first (sets _currentSessionId and subscribes to events)
+            do {
+                try await client.attachSession(sessionId: sessionId)
+            } catch {
+                print("[ConversationView] Failed to attach session: \(error)")
+                showError(error.localizedDescription)
+            }
+            await startEventSubscription()
+        }
+        .onDisappear {
+            eventTask?.cancel()
+        }
+    }
+
+    // MARK: - Views
+
+    @ViewBuilder
+    private func itemView(_ item: ConversationItem) -> some View {
+        switch item {
+        case .userMessage(_, let text):
+            userBubble(text)
+        case .assistantText(_, let text):
+            assistantBubble(text)
+        case .toolCall(let id, let name, let args, let output, let status):
+            toolCallCard(id: id, name: name, args: args, output: output, status: status)
+        }
+    }
+
+    private func userBubble(_ text: String) -> some View {
+        HStack {
+            Spacer(minLength: 60)
+            Text(text)
+                .font(.body)
+                .foregroundColor(Theme.text)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Theme.userMessageBg)
+                .cornerRadius(16)
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private func assistantBubble(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Circle()
+                .fill(Theme.accent)
+                .frame(width: 8, height: 8)
+                .padding(.top, 6)
+
+            Text(text)
+                .font(.body)
+                .foregroundColor(Theme.text)
+                .textSelection(.enabled)
+
+            Spacer(minLength: 40)
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private func toolCallCard(id: String, name: String, args: String?, output: String?, status: ToolCallStatus) -> some View {
+        let isExpanded = expandedToolCalls.contains(id)
+        let parsedArgs = parseArgs(args)
+
+        return VStack(alignment: .leading, spacing: 0) {
+            // Header - tappable
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    if isExpanded {
+                        expandedToolCalls.remove(id)
+                    } else {
+                        expandedToolCalls.insert(id)
+                    }
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Circle()
+                        .fill(Theme.toolStatusColor(status))
+                        .frame(width: 8, height: 8)
+
+                    toolHeaderText(name: name, args: parsedArgs)
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(Theme.dim)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            // Expanded content
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    // Show args if present
+                    if let args, !args.isEmpty {
+                        Text("Arguments:")
+                            .font(.caption)
+                            .foregroundColor(Theme.dim)
+
+                        Text(formatJSON(args))
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundColor(Theme.muted)
+                            .textSelection(.enabled)
+                    }
+
+                    // Show output if present
+                    if let output, !output.isEmpty {
+                        Divider()
+                            .background(Theme.borderMuted)
+
+                        Text("Output:")
+                            .font(.caption)
+                            .foregroundColor(Theme.dim)
+
+                        ScrollView {
+                            Text(truncateOutput(output))
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundColor(Theme.muted)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .frame(maxHeight: 150)
+                    }
+                }
+                .padding(.top, 10)
+                .padding(.leading, 18)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Theme.toolStatusBg(status))
+        .cornerRadius(10)
+        .padding(.horizontal, 16)
+    }
+
+    @ViewBuilder
+    private func toolHeaderText(name: String, args: [String: Any]) -> some View {
+        switch name {
+        case "read":
+            let path = shortenPath(args["path"] as? String ?? "")
+            HStack(spacing: 4) {
+                Text("read")
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Theme.text)
+                Text(path.isEmpty ? "..." : path)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(Theme.accent)
+                    .lineLimit(1)
+            }
+
+        case "write":
+            let path = shortenPath(args["path"] as? String ?? "")
+            HStack(spacing: 4) {
+                Text("write")
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Theme.text)
+                Text(path.isEmpty ? "..." : path)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(Theme.accent)
+                    .lineLimit(1)
+            }
+
+        case "edit":
+            let path = shortenPath(args["path"] as? String ?? "")
+            HStack(spacing: 4) {
+                Text("edit")
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Theme.text)
+                Text(path.isEmpty ? "..." : path)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(Theme.accent)
+                    .lineLimit(1)
+            }
+
+        case "bash":
+            let command = args["command"] as? String ?? ""
+            HStack(spacing: 4) {
+                Text("$")
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Theme.text)
+                Text(command.isEmpty ? "..." : truncateText(command, maxLength: 30))
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(Theme.muted)
+                    .lineLimit(1)
+            }
+
+        case "grep":
+            let pattern = args["pattern"] as? String ?? ""
+            HStack(spacing: 4) {
+                Text("grep")
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Theme.text)
+                Text(pattern.isEmpty ? "..." : "/\(pattern)/")
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundColor(Theme.accent)
+                    .lineLimit(1)
+            }
+
+        default:
+            HStack(spacing: 4) {
+                Text(name)
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Theme.text)
+            }
+        }
+    }
+
+    private var inputArea: some View {
+        HStack(alignment: .bottom, spacing: 12) {
+            TextField("Message...", text: $inputText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(.body)
+                .foregroundColor(Theme.text)
+                .focused($isInputFocused)
+                .lineLimit(1...6)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(Theme.cardBg)
+                .cornerRadius(20)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Theme.borderMuted, lineWidth: 1)
+                )
+
+            if isProcessing {
+                Button {
+                    Task { await abortOperation() }
+                } label: {
+                    Image(systemName: "stop.circle.fill")
+                        .font(.system(size: 32))
+                        .foregroundColor(Theme.error)
+                }
+            } else {
+                Button {
+                    Task { await sendMessage() }
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 32))
+                        .foregroundColor(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? Theme.dim : Theme.accent)
+                }
+                .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Theme.inputBg)
+    }
+
+    // MARK: - Actions
+
+    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            withAnimation(.easeOut(duration: 0.2)) {
+                proxy.scrollTo("bottom", anchor: .bottom)
+            }
+        }
+    }
+
+    private func sendMessage() async {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        // Add user message to items
+        let userMessageId = UUID().uuidString
+        items.append(.userMessage(id: userMessageId, text: text))
+        inputText = ""
+        isInputFocused = false
+
+        do {
+            try await client.prompt(text)
+        } catch {
+            showError(error.localizedDescription)
+        }
+    }
+
+    private func abortOperation() async {
+        do {
+            try await client.abort()
+        } catch {
+            showError(error.localizedDescription)
+        }
+    }
+
+    private func clearConversation() async {
+        do {
+            try await client.clearConversation()
+            items.removeAll()
+            currentStreamingText = ""
+            currentStreamingId = nil
+        } catch {
+            showError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Event Handling
+
+    private func startEventSubscription() async {
+        eventTask = Task {
+            let events = await client.events
+
+            for await event in events {
+                guard !Task.isCancelled else { break }
+                handleEvent(event)
+            }
+        }
+    }
+
+    @MainActor
+    private func handleEvent(_ event: RPCEvent) {
+        switch event {
+        case .agentStart:
+            isProcessing = true
+            currentStreamingText = ""
+            currentStreamingId = UUID().uuidString
+
+        case .agentEnd(let success, let error):
+            isProcessing = false
+
+            // Finalize any streaming text
+            if !currentStreamingText.isEmpty, let streamId = currentStreamingId {
+                items.append(.assistantText(id: streamId, text: currentStreamingText))
+                currentStreamingText = ""
+                currentStreamingId = nil
+            }
+
+            if !success, let error {
+                showError(error.message)
+            }
+
+        case .turnStart:
+            break
+
+        case .turnEnd:
+            break
+
+        case .messageStart:
+            break
+
+        case .messageEnd:
+            // Finalize streaming text
+            if !currentStreamingText.isEmpty, let streamId = currentStreamingId {
+                items.append(.assistantText(id: streamId, text: currentStreamingText))
+                currentStreamingText = ""
+                currentStreamingId = UUID().uuidString
+            }
+
+        case .messageUpdate(_, let assistantEvent):
+            handleAssistantEvent(assistantEvent)
+
+        case .toolExecutionStart(let toolCallId, let toolName, let args):
+            // Finalize any streaming text first
+            if !currentStreamingText.isEmpty, let streamId = currentStreamingId {
+                items.append(.assistantText(id: streamId, text: currentStreamingText))
+                currentStreamingText = ""
+                currentStreamingId = UUID().uuidString
+            }
+
+            let argsString = args?.jsonString
+            items.append(.toolCall(
+                id: toolCallId,
+                name: toolName,
+                args: argsString,
+                output: nil,
+                status: .running
+            ))
+
+        case .toolExecutionUpdate(let toolCallId, let output):
+            updateToolCall(id: toolCallId, output: output, status: .running)
+
+        case .toolExecutionEnd(let toolCallId, let output, let status):
+            let toolStatus: ToolCallStatus = switch status {
+            case .success: .success
+            case .error, .cancelled: .error
+            }
+            updateToolCall(id: toolCallId, output: output, status: toolStatus)
+
+        case .autoCompactionStart:
+            break
+
+        case .autoCompactionEnd:
+            break
+
+        case .autoRetryStart:
+            break
+
+        case .autoRetryEnd:
+            break
+
+        case .hookError(_, _, let errorMsg):
+            if let errorMsg {
+                showError("Hook error: \(errorMsg)")
+            }
+
+        case .stateUpdate:
+            break
+
+        case .unknown:
+            break
+        }
+    }
+
+    private func handleAssistantEvent(_ event: AssistantMessageEvent) {
+        switch event {
+        case .textDelta(let delta):
+            currentStreamingText += delta
+
+        case .thinkingDelta:
+            // Could show thinking indicator, for now ignore
+            break
+
+        case .toolUseStart(let toolCallId, let toolName):
+            // Finalize streaming text
+            if !currentStreamingText.isEmpty, let streamId = currentStreamingId {
+                items.append(.assistantText(id: streamId, text: currentStreamingText))
+                currentStreamingText = ""
+                currentStreamingId = UUID().uuidString
+            }
+
+            items.append(.toolCall(
+                id: toolCallId,
+                name: toolName,
+                args: nil,
+                output: nil,
+                status: .running
+            ))
+
+        case .toolUseInputDelta(let toolCallId, let delta):
+            // Update args for the tool call
+            if let index = items.firstIndex(where: { $0.id == toolCallId }) {
+                if case .toolCall(let id, let name, let existingArgs, let output, let status) = items[index] {
+                    let newArgs = (existingArgs ?? "") + delta
+                    items[index] = .toolCall(id: id, name: name, args: newArgs, output: output, status: status)
+                }
+            }
+
+        case .toolUseEnd:
+            break
+
+        case .messageStart:
+            break
+
+        case .messageEnd:
+            break
+
+        case .contentBlockStart:
+            break
+
+        case .contentBlockEnd:
+            break
+
+        case .unknown:
+            break
+        }
+    }
+
+    private func updateToolCall(id: String, output: String?, status: ToolCallStatus) {
+        if let index = items.firstIndex(where: { $0.id == id }) {
+            if case .toolCall(let existingId, let name, let args, let existingOutput, _) = items[index] {
+                let newOutput = output ?? existingOutput
+                items[index] = .toolCall(id: existingId, name: name, args: args, output: newOutput, status: status)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func showError(_ message: String) {
+        errorMessage = message
+        showError = true
+    }
+
+    private func parseArgs(_ args: String?) -> [String: Any] {
+        guard let args,
+              let data = args.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return json
+    }
+
+    private func formatJSON(_ jsonString: String) -> String {
+        guard let data = jsonString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let prettyData = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted),
+              let prettyString = String(data: prettyData, encoding: .utf8) else {
+            return jsonString
+        }
+        return prettyString
+    }
+
+    private func shortenPath(_ path: String) -> String {
+        // Try to shorten long paths
+        let components = path.components(separatedBy: "/")
+        if components.count > 3 {
+            return ".../" + components.suffix(2).joined(separator: "/")
+        }
+        return path
+    }
+
+    private func truncateText(_ text: String, maxLength: Int) -> String {
+        let cleaned = text.replacingOccurrences(of: "\n", with: " ")
+        if cleaned.count > maxLength {
+            return String(cleaned.prefix(maxLength)) + "..."
+        }
+        return cleaned
+    }
+
+    private func truncateOutput(_ output: String) -> String {
+        let lines = output.components(separatedBy: .newlines)
+        let maxLines = 30
+        if lines.count > maxLines {
+            return lines.prefix(maxLines).joined(separator: "\n") + "\n... (\(lines.count - maxLines) more lines)"
+        }
+        return output
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        // Note: Preview won't work without actual client
+        // This is just for layout preview
+        VStack {
+            Text("Preview not available - requires RPCClient")
+                .foregroundColor(.gray)
+        }
+    }
+}

--- a/apps/mobile/Sources/Views/MainView.swift
+++ b/apps/mobile/Sources/Views/MainView.swift
@@ -1,0 +1,154 @@
+//
+//  MainView.swift
+//  Pi
+//
+//  Main app view that manages navigation and state
+//
+
+import SwiftUI
+import PiCore
+
+/// Main app view that handles the navigation flow
+struct MainView: View {
+    @StateObject private var serverConfig = ServerConfig.shared
+    @State private var client: RPCClient?
+    @State private var selectedRepo: RepoInfo?
+    @State private var selectedSessionId: String?
+    @State private var navigationPath = NavigationPath()
+
+    var body: some View {
+        Group {
+            if !serverConfig.isConfigured {
+                // Show server setup
+                ServerSetupView {
+                    // Server configured - create client
+                    createClient()
+                }
+            } else if client == nil {
+                // Connecting to server
+                connectingView
+            } else if let client {
+                // Main navigation
+                NavigationStack(path: $navigationPath) {
+                    RepoListView(client: client) { repo in
+                        selectedRepo = repo
+                        navigationPath.append(NavigationDestination.sessions(repo: repo))
+                    }
+                    .navigationDestination(for: NavigationDestination.self) { destination in
+                        switch destination {
+                        case .sessions(let repo):
+                            SessionListView(
+                                client: client,
+                                repoId: repo.id,
+                                repoName: repo.name
+                            ) { sessionId in
+                                selectedSessionId = sessionId
+                                navigationPath.append(NavigationDestination.conversation(sessionId: sessionId))
+                            }
+                        case .conversation(let sessionId):
+                            ConversationView(client: client, sessionId: sessionId) {
+                                // Pop back to sessions when disconnected
+                                navigationPath.removeLast()
+                            }
+                        }
+                    }
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            Menu {
+                                Button(role: .destructive) {
+                                    disconnect()
+                                } label: {
+                                    Label("Disconnect", systemImage: "wifi.slash")
+                                }
+                            } label: {
+                                Image(systemName: "ellipsis.circle")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            if serverConfig.isConfigured && client == nil {
+                createClient()
+            }
+        }
+    }
+
+    // MARK: - Connecting View
+
+    private var connectingView: some View {
+        VStack(spacing: 20) {
+            ProgressView()
+                .scaleEffect(1.5)
+
+            Text("Connecting to server...")
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.pageBg)
+    }
+
+    // MARK: - Actions
+
+    private func createClient() {
+        guard let url = serverConfig.serverURL else { return }
+
+        print("[MainView] Creating RPCClient for \(url)")
+        let newClient = RPCClient(serverURL: url)
+
+        Task {
+            do {
+                print("[MainView] Connecting...")
+                try await newClient.connect()
+                print("[MainView] Connected successfully!")
+                await MainActor.run {
+                    self.client = newClient
+                }
+            } catch {
+                print("[MainView] Connection failed: \(error)")
+                // Connection failed - clear config to show setup again
+                await MainActor.run {
+                    serverConfig.clearServerURL()
+                }
+            }
+        }
+    }
+
+    private func disconnect() {
+        Task {
+            await client?.disconnect()
+            await MainActor.run {
+                client = nil
+                selectedRepo = nil
+                selectedSessionId = nil
+                navigationPath = NavigationPath()
+                serverConfig.clearServerURL()
+            }
+        }
+    }
+}
+
+// MARK: - Navigation Destination
+
+enum NavigationDestination: Hashable {
+    case sessions(repo: RepoInfo)
+    case conversation(sessionId: String)
+}
+
+// Make RepoInfo Hashable for navigation
+extension RepoInfo: Hashable {
+    public static func == (lhs: RepoInfo, rhs: RepoInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    MainView()
+}

--- a/apps/mobile/Sources/Views/RepoListView.swift
+++ b/apps/mobile/Sources/Views/RepoListView.swift
@@ -1,0 +1,215 @@
+//
+//  RepoListView.swift
+//  Pi
+//
+//  View for selecting a repository from available repos
+//
+
+import SwiftUI
+import PiCore
+
+struct RepoListView: View {
+    let client: RPCClient
+    let onRepoSelected: (RepoInfo) -> Void
+
+    @State private var repos: [RepoInfo] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Group {
+            if isLoading {
+                loadingView
+            } else if let error = errorMessage {
+                errorView(error)
+            } else if repos.isEmpty {
+                emptyView
+            } else {
+                repoListView
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.pageBg)
+        .navigationTitle("Select Repository")
+        .task {
+            await loadRepos()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .scaleEffect(1.2)
+                .tint(Theme.accent)
+
+            Text("Loading repositories...")
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    private func errorView(_ error: String) -> some View {
+        VStack(spacing: 24) {
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Theme.error)
+
+                Text("Failed to Load Repositories")
+                    .font(.headline)
+                    .foregroundStyle(Theme.text)
+
+                Text(error)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Button(action: { Task { await loadRepos() } }) {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.clockwise")
+                    Text("Retry")
+                        .fontWeight(.semibold)
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+                .background(Theme.accent)
+                .foregroundStyle(.white)
+                .cornerRadius(8)
+            }
+        }
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "folder.badge.questionmark")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.muted)
+
+            Text("No Repositories Found")
+                .font(.headline)
+                .foregroundStyle(Theme.text)
+
+            Text("Add a repository to your Pi server to get started")
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button(action: { Task { await loadRepos() } }) {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.clockwise")
+                    Text("Refresh")
+                }
+                .font(.subheadline)
+                .foregroundStyle(Theme.accent)
+            }
+            .padding(.top, 8)
+        }
+    }
+
+    private var repoListView: some View {
+        List(repos, id: \.id) { repo in
+            Button {
+                onRepoSelected(repo)
+            } label: {
+                repoRow(repo)
+            }
+            .listRowBackground(Theme.cardBg)
+            .listRowSeparatorTint(Theme.borderMuted)
+        }
+        .listStyle(.plain)
+        .refreshable {
+            await loadRepos()
+        }
+    }
+
+    private func repoRow(_ repo: RepoInfo) -> some View {
+        HStack(spacing: 12) {
+            // Folder icon
+            Image(systemName: "folder.fill")
+                .font(.title2)
+                .foregroundStyle(Theme.accent)
+                .frame(width: 32)
+
+            // Repo info
+            VStack(alignment: .leading, spacing: 4) {
+                Text(repo.name)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .foregroundStyle(Theme.text)
+
+                Text(repo.path)
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer()
+
+            // Chevron indicator
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(Theme.muted)
+        }
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Data Loading
+
+    private func loadRepos() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            repos = try await client.listRepos()
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("With Repos") {
+    NavigationStack {
+        RepoListView(
+            client: RPCClient(serverURL: URL(string: "ws://localhost:3000")!)
+        ) { repo in
+            print("Selected: \(repo.name)")
+        }
+    }
+}
+
+#Preview("Empty State") {
+    NavigationStack {
+        // Preview of empty state - in real use this would show when no repos exist
+        VStack(spacing: 16) {
+            Image(systemName: "folder.badge.questionmark")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.muted)
+
+            Text("No Repositories Found")
+                .font(.headline)
+                .foregroundStyle(Theme.text)
+
+            Text("Add a repository to your Pi server to get started")
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.pageBg)
+        .navigationTitle("Select Repository")
+    }
+}

--- a/apps/mobile/Sources/Views/ServerSetupView.swift
+++ b/apps/mobile/Sources/Views/ServerSetupView.swift
@@ -1,0 +1,253 @@
+//
+//  ServerSetupView.swift
+//  Pi
+//
+//  View for entering and connecting to a Pi server URL
+//
+
+import SwiftUI
+import PiCore
+
+struct ServerSetupView: View {
+    @ObservedObject private var serverConfig = ServerConfig.shared
+    @State private var urlText = "ws://localhost:3000"
+    @State private var isConnecting = false
+    @State private var errorMessage: String?
+    @State private var showSuccess = false
+
+    let onConnected: () -> Void
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+
+            // Logo and title
+            VStack(spacing: 16) {
+                Image("PiLogo")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 80, height: 80)
+                    .foregroundStyle(Theme.accent)
+
+                Text("Connect to Server")
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundStyle(Theme.text)
+
+                Text("Enter your Pi server URL to get started")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            // URL input section
+            VStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Server URL")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(Theme.textSecondary)
+
+                    TextField("ws://localhost:3000", text: $urlText)
+                        .textFieldStyle(.plain)
+                        .padding(12)
+                        .background(Theme.inputBg)
+                        .cornerRadius(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(errorMessage != nil ? Theme.error : Theme.borderMuted, lineWidth: 1)
+                        )
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                        .disabled(isConnecting)
+                }
+
+                // Error message
+                if let error = errorMessage {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.circle.fill")
+                            .foregroundStyle(Theme.error)
+
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(Theme.error)
+
+                        Spacer()
+                    }
+                }
+
+                // Success indicator
+                if showSuccess {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(Theme.success)
+
+                        Text("Connected successfully!")
+                            .font(.caption)
+                            .foregroundStyle(Theme.success)
+
+                        Spacer()
+                    }
+                }
+            }
+            .padding(.horizontal, 24)
+
+            // Connect button
+            Button(action: { Task { await connect() } }) {
+                HStack(spacing: 8) {
+                    if isConnecting {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .scaleEffect(0.8)
+                            .tint(.white)
+                    } else {
+                        Image(systemName: "arrow.right.circle.fill")
+                    }
+                    Text(isConnecting ? "Connecting..." : "Connect")
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(isConnecting ? Theme.muted : Theme.accent)
+                .foregroundStyle(.white)
+                .cornerRadius(10)
+            }
+            .disabled(isConnecting || urlText.trimmingCharacters(in: .whitespaces).isEmpty)
+            .padding(.horizontal, 24)
+
+            Spacer()
+
+            // Help text
+            Text("Make sure the Pi server is running and accessible")
+                .font(.caption2)
+                .foregroundStyle(Theme.dim)
+                .padding(.bottom, 24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.pageBg)
+        .onAppear {
+            // Pre-fill with saved URL if available
+            if let savedURL = serverConfig.serverURL {
+                urlText = savedURL.absoluteString
+            }
+        }
+    }
+
+    // MARK: - Connection Logic
+
+    private func connect() async {
+        // Reset state
+        errorMessage = nil
+        showSuccess = false
+        isConnecting = true
+
+        defer { isConnecting = false }
+
+        // Validate URL format
+        let trimmedURL = urlText.trimmingCharacters(in: .whitespaces)
+        guard let url = URL(string: trimmedURL) else {
+            errorMessage = "Invalid URL format"
+            return
+        }
+
+        // Ensure it's a WebSocket URL
+        guard url.scheme == "ws" || url.scheme == "wss" else {
+            errorMessage = "URL must start with ws:// or wss://"
+            return
+        }
+
+        // Test connection
+        do {
+            try await testConnection(url: url)
+
+            // Success - save URL and notify
+            showSuccess = true
+            serverConfig.setServerURL(url)
+
+            // Small delay to show success state
+            try? await Task.sleep(nanoseconds: 500_000_000) // 0.5s
+
+            onConnected()
+        } catch let error as RPCTransportError {
+            errorMessage = error.localizedDescription
+        } catch {
+            errorMessage = "Connection failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func testConnection(url: URL) async throws {
+        // Build WebSocket URL
+        var wsURL = url
+        if !wsURL.path.hasSuffix("/rpc") {
+            wsURL = url.appendingPathComponent("rpc")
+        }
+
+        // Simple WebSocket test without full transport
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: wsURL)
+        task.resume()
+
+        // Send hello
+        let hello: [String: Any] = [
+            "v": 1,
+            "kind": "request",
+            "id": "test-hello",
+            "method": "hello",
+            "params": [
+                "client": [
+                    "name": "pi-mobile",
+                    "version": "1.0"
+                ]
+            ]
+        ]
+
+        let helloData = try JSONSerialization.data(withJSONObject: hello)
+        try await task.send(.data(helloData))
+
+        // Receive response with timeout
+        let response = try await withThrowingTaskGroup(of: URLSessionWebSocketTask.Message.self) { group in
+            group.addTask {
+                try await task.receive()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 10_000_000_000)
+                throw RPCTransportError.timeout
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
+        // Parse response
+        let responseData: Data
+        switch response {
+        case .data(let data):
+            responseData = data
+        case .string(let str):
+            responseData = str.data(using: .utf8) ?? Data()
+        @unknown default:
+            throw RPCTransportError.invalidResponse("Unknown message type")
+        }
+
+        // Verify it's a valid hello response
+        guard let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              let ok = json["ok"] as? Bool, ok,
+              let result = json["result"] as? [String: Any],
+              result["connectionId"] != nil else {
+            throw RPCTransportError.invalidResponse("Invalid hello response")
+        }
+
+        // Clean up
+        task.cancel(with: .normalClosure, reason: nil)
+        session.invalidateAndCancel()
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ServerSetupView {
+        print("Connected!")
+    }
+}

--- a/apps/mobile/Sources/Views/SessionListView.swift
+++ b/apps/mobile/Sources/Views/SessionListView.swift
@@ -1,0 +1,351 @@
+//
+//  SessionListView.swift
+//  Pi
+//
+//  View for managing sessions within a repository
+//
+
+import SwiftUI
+import PiCore
+
+struct SessionListView: View {
+    let client: RPCClient
+    let repoId: String
+    let repoName: String
+    let onSessionSelected: (String) -> Void
+
+    @State private var sessions: [SessionInfoResult] = []
+    @State private var isLoading = true
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+    @State private var sessionToDelete: SessionInfoResult?
+    @State private var showDeleteConfirmation = false
+
+    var body: some View {
+        ZStack {
+            Theme.pageBg.ignoresSafeArea()
+
+            if isLoading && sessions.isEmpty {
+                loadingView
+            } else if let error = errorMessage, sessions.isEmpty {
+                errorView(error)
+            } else if sessions.isEmpty {
+                emptyStateView
+            } else {
+                sessionListView
+            }
+        }
+        .navigationTitle(repoName)
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                createSessionButton
+            }
+        }
+        .alert("Delete Session", isPresented: $showDeleteConfirmation, presenting: sessionToDelete) { session in
+            Button("Cancel", role: .cancel) {
+                sessionToDelete = nil
+            }
+            Button("Delete", role: .destructive) {
+                Task {
+                    await deleteSession(session.sessionId)
+                }
+            }
+        } message: { _ in
+            Text("Are you sure you want to delete this session? This action cannot be undone.")
+        }
+        .task {
+            await loadSessions()
+        }
+        .refreshable {
+            await loadSessions()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .scaleEffect(1.2)
+                .tint(Theme.accent)
+
+            Text("Loading sessions...")
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    private func errorView(_ error: String) -> some View {
+        VStack(spacing: 20) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.error)
+
+            Text("Failed to Load Sessions")
+                .font(.headline)
+                .foregroundStyle(Theme.text)
+
+            Text(error)
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button(action: { Task { await loadSessions() } }) {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.clockwise")
+                    Text("Retry")
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+                .background(Theme.accent)
+                .foregroundStyle(.white)
+                .cornerRadius(8)
+            }
+        }
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.muted)
+
+            Text("No Sessions Yet")
+                .font(.headline)
+                .foregroundStyle(Theme.text)
+
+            Text("Create a new session to start a conversation with the AI assistant.")
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button(action: { Task { await createSession() } }) {
+                HStack(spacing: 8) {
+                    if isCreating {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .scaleEffect(0.8)
+                            .tint(.white)
+                    } else {
+                        Image(systemName: "plus.circle.fill")
+                    }
+                    Text(isCreating ? "Creating..." : "Create Session")
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+                .background(isCreating ? Theme.muted : Theme.accent)
+                .foregroundStyle(.white)
+                .cornerRadius(8)
+            }
+            .disabled(isCreating)
+        }
+    }
+
+    private var sessionListView: some View {
+        List {
+            ForEach(sessions) { session in
+                SessionRowView(session: session)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        onSessionSelected(session.sessionId)
+                    }
+                    .listRowBackground(Theme.cardBg)
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            sessionToDelete = session
+                            showDeleteConfirmation = true
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+    }
+
+    private var createSessionButton: some View {
+        Button(action: { Task { await createSession() } }) {
+            if isCreating {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .scaleEffect(0.8)
+                    .tint(Theme.accent)
+            } else {
+                Image(systemName: "plus")
+                    .fontWeight(.semibold)
+            }
+        }
+        .disabled(isCreating)
+    }
+
+    // MARK: - Data Operations
+
+    private func loadSessions() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let loadedSessions = try await client.listSessions(repoId: repoId)
+            // Sort by creation date, newest first
+            sessions = loadedSessions.sorted { session1, session2 in
+                guard let date1 = session1.createdAt else { return false }
+                guard let date2 = session2.createdAt else { return true }
+                return date1 > date2
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    private func createSession() async {
+        isCreating = true
+        errorMessage = nil
+
+        do {
+            let result = try await client.createSession(repoId: repoId)
+            // Reload sessions to get the new one with full info
+            await loadSessions()
+            // Navigate to the new session
+            onSessionSelected(result.sessionId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isCreating = false
+    }
+
+    private func deleteSession(_ sessionId: String) async {
+        do {
+            try await client.deleteSession(sessionId: sessionId)
+            // Remove from local state
+            sessions.removeAll { $0.sessionId == sessionId }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        sessionToDelete = nil
+    }
+}
+
+// MARK: - Session Row View
+
+private struct SessionRowView: View {
+    let session: SessionInfoResult
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Session icon
+            ZStack {
+                Circle()
+                    .fill(Theme.accent.opacity(0.15))
+                    .frame(width: 44, height: 44)
+
+                Image(systemName: "bubble.left.fill")
+                    .font(.system(size: 18))
+                    .foregroundStyle(Theme.accent)
+            }
+
+            // Session info
+            VStack(alignment: .leading, spacing: 4) {
+                Text(truncatedSessionId)
+                    .font(.headline)
+                    .foregroundStyle(Theme.text)
+                    .lineLimit(1)
+
+                if let createdAt = session.createdAt {
+                    Text(formatDate(createdAt))
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                if let lastActivity = session.lastActivityAt, lastActivity != session.createdAt {
+                    Text("Last active: \(formatRelativeDate(lastActivity))")
+                        .font(.caption2)
+                        .foregroundStyle(Theme.dim)
+                }
+            }
+
+            Spacer()
+
+            // Chevron indicator
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Theme.muted)
+        }
+        .padding(.vertical, 8)
+    }
+
+    private var truncatedSessionId: String {
+        let id = session.sessionId
+        if id.count > 12 {
+            return String(id.prefix(8)) + "..."
+        }
+        return id
+    }
+
+    private func formatDate(_ dateString: String) -> String {
+        // Try to parse ISO 8601 date
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        if let date = formatter.date(from: dateString) {
+            let displayFormatter = DateFormatter()
+            displayFormatter.dateStyle = .medium
+            displayFormatter.timeStyle = .short
+            return "Created \(displayFormatter.string(from: date))"
+        }
+
+        // Fallback: try without fractional seconds
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: dateString) {
+            let displayFormatter = DateFormatter()
+            displayFormatter.dateStyle = .medium
+            displayFormatter.timeStyle = .short
+            return "Created \(displayFormatter.string(from: date))"
+        }
+
+        return "Created \(dateString)"
+    }
+
+    private func formatRelativeDate(_ dateString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        var date = formatter.date(from: dateString)
+
+        // Fallback: try without fractional seconds
+        if date == nil {
+            formatter.formatOptions = [.withInternetDateTime]
+            date = formatter.date(from: dateString)
+        }
+
+        guard let parsedDate = date else {
+            return dateString
+        }
+
+        let relativeFormatter = RelativeDateTimeFormatter()
+        relativeFormatter.unitsStyle = .short
+        return relativeFormatter.localizedString(for: parsedDate, relativeTo: Date())
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        SessionListView(
+            client: RPCClient(serverURL: URL(string: "ws://localhost:3000")!),
+            repoId: "test-repo",
+            repoName: "Test Repository"
+        ) { sessionId in
+            print("Selected session: \(sessionId)")
+        }
+    }
+}

--- a/apps/server/.gitignore
+++ b/apps/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,179 @@
+# Pi Server
+
+WebSocket server for the pi coding agent. Enables remote clients (iOS, etc.) to use pi's AgentSession via WebSocket.
+
+## Quick Start
+
+```bash
+# Install dependencies
+bun install
+
+# Run in development mode (with hot reload)
+bun run dev
+
+# Build standalone binary
+bun run build
+```
+
+## Configuration
+
+### CLI Options
+
+```bash
+pi-server [options]
+
+Options:
+  --port, -p <port>       Listen port (default: 3000)
+  --host <host>           Bind host (default: 0.0.0.0)
+  --data-dir <path>       Data directory
+  --help, -h              Show help
+```
+
+### Environment Variables
+
+- `PI_SERVER_PORT` - Listen port
+- `PI_SERVER_DATA_DIR` - Data directory
+
+### .env File
+
+The server loads a `.env` file from the data directory if it exists. Use this to set API keys for additional providers:
+
+```bash
+# <data-dir>/.env
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### Authentication
+
+For pi authentication, symlink or copy your `auth.json`:
+
+```bash
+ln -s ~/.pi/agent/auth.json /path/to/data-dir/auth.json
+```
+
+### Data Directory
+
+Default location follows XDG spec:
+- `$XDG_DATA_HOME/pi-server/` if set
+- `~/.local/share/pi-server/` otherwise
+
+Structure:
+```
+<data-dir>/
+├── .env                # Environment variables (API keys)
+├── auth.json           # Pi authentication (symlink to ~/.pi/agent/auth.json)
+├── repos.json          # Repository definitions
+├── sessions/           # Pi session files
+├── worktrees/          # Git worktrees (one per session)
+└── state.json          # Server state
+```
+
+## Repo Configuration
+
+Create `repos.json` in your data directory:
+
+```json
+{
+  "repos": [
+    {
+      "id": "my-project",
+      "name": "My Project",
+      "path": "/home/user/code/my-project"
+    }
+  ]
+}
+```
+
+## WebSocket Protocol
+
+Connect to `ws://<host>:<port>/rpc`
+
+### Message Format
+
+**Request (client → server):**
+```json
+{
+  "v": 1,
+  "kind": "request",
+  "id": "unique-id",
+  "sessionId": "session-uuid",
+  "method": "prompt",
+  "params": { "message": "Hello" }
+}
+```
+
+**Response (server → client):**
+```json
+{
+  "v": 1,
+  "kind": "response",
+  "id": "unique-id",
+  "ok": true,
+  "result": { ... }
+}
+```
+
+**Event (server → client):**
+```json
+{
+  "v": 1,
+  "kind": "event",
+  "sessionId": "session-uuid",
+  "seq": 1,
+  "type": "message_update",
+  "payload": { ... }
+}
+```
+
+### Methods
+
+| Method | Params | Description |
+|--------|--------|-------------|
+| `hello` | `{client: {name, version}, resume?}` | Handshake, returns connectionId |
+| `repos.list` | - | List available repos |
+| `session.create` | `{repoId}` | Create new session with worktree |
+| `session.list` | - | List all sessions |
+| `session.attach` | `{sessionId}` | Attach to receive session events |
+| `session.delete` | `{sessionId}` | Delete session and worktree |
+| `prompt` | `{message}` | Send prompt (requires sessionId) |
+| `abort` | - | Abort current operation |
+| `get_state` | - | Get session state |
+| `get_messages` | - | Get conversation history |
+| `get_available_models` | - | List available models |
+| `set_model` | `{provider, modelId}` | Change model |
+
+### Events
+
+Events from the agent are forwarded to attached clients:
+- `agent_start` / `agent_end`
+- `message_start` / `message_update` / `message_end`
+- `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
+- `turn_start` / `turn_end`
+- etc.
+
+## HTTP Endpoints
+
+- `GET /` - Server info
+- `GET /health` - Health check
+
+## Development
+
+```bash
+# Type check
+bun run typecheck
+
+# Run with watch
+bun run dev
+```
+
+## Deployment
+
+Build a standalone binary:
+
+```bash
+bun run build
+./dist/pi-server --port 3000 --data-dir /var/lib/pi-server
+```
+
+The binary includes all dependencies and can be deployed without Node.js/Bun installed.

--- a/apps/server/biome.json
+++ b/apps/server/biome.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "vcs": {
+    "enabled": false
+  },
+  "files": {
+    "includes": ["**/*.ts", "**/*.json"],
+    "ignoreUnknown": true
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  }
+}

--- a/apps/server/bun.lock
+++ b/apps/server/bun.lock
@@ -1,0 +1,517 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pi-server",
+      "dependencies": {
+        "@mariozechner/pi-coding-agent": "^0.45.5",
+        "hono": "^4",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.968.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "3.968.0", "@aws-sdk/credential-provider-node": "3.968.0", "@aws-sdk/eventstream-handler-node": "3.968.0", "@aws-sdk/middleware-eventstream": "3.968.0", "@aws-sdk/middleware-host-header": "3.968.0", "@aws-sdk/middleware-logger": "3.968.0", "@aws-sdk/middleware-recursion-detection": "3.968.0", "@aws-sdk/middleware-user-agent": "3.968.0", "@aws-sdk/middleware-websocket": "3.968.0", "@aws-sdk/region-config-resolver": "3.968.0", "@aws-sdk/token-providers": "3.968.0", "@aws-sdk/types": "3.968.0", "@aws-sdk/util-endpoints": "3.968.0", "@aws-sdk/util-user-agent-browser": "3.968.0", "@aws-sdk/util-user-agent-node": "3.968.0", "@smithy/config-resolver": "^4.4.5", "@smithy/core": "^3.20.3", "@smithy/eventstream-serde-browser": "^4.2.7", "@smithy/eventstream-serde-config-resolver": "^4.3.7", "@smithy/eventstream-serde-node": "^4.2.7", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/hash-node": "^4.2.7", "@smithy/invalid-dependency": "^4.2.7", "@smithy/middleware-content-length": "^4.2.7", "@smithy/middleware-endpoint": "^4.4.4", "@smithy/middleware-retry": "^4.4.20", "@smithy/middleware-serde": "^4.2.8", "@smithy/middleware-stack": "^4.2.7", "@smithy/node-config-provider": "^4.3.7", "@smithy/node-http-handler": "^4.4.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.5", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.19", "@smithy/util-defaults-mode-node": "^4.2.22", "@smithy/util-endpoints": "^3.2.7", "@smithy/util-middleware": "^4.2.7", "@smithy/util-retry": "^4.2.7", "@smithy/util-stream": "^4.5.8", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-4ELe/yI2/PrYuOcvvRiyIO3HXGsRpPp1xj/bKtKfvns+Io06w60qmriAEjApvwyorfYcXFXn+oaTibmVx5DeAQ=="],
+
+    "@aws-sdk/client-sso": ["@aws-sdk/client-sso@3.968.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "3.968.0", "@aws-sdk/middleware-host-header": "3.968.0", "@aws-sdk/middleware-logger": "3.968.0", "@aws-sdk/middleware-recursion-detection": "3.968.0", "@aws-sdk/middleware-user-agent": "3.968.0", "@aws-sdk/region-config-resolver": "3.968.0", "@aws-sdk/types": "3.968.0", "@aws-sdk/util-endpoints": "3.968.0", "@aws-sdk/util-user-agent-browser": "3.968.0", "@aws-sdk/util-user-agent-node": "3.968.0", "@smithy/config-resolver": "^4.4.5", "@smithy/core": "^3.20.3", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/hash-node": "^4.2.7", "@smithy/invalid-dependency": "^4.2.7", "@smithy/middleware-content-length": "^4.2.7", "@smithy/middleware-endpoint": "^4.4.4", "@smithy/middleware-retry": "^4.4.20", "@smithy/middleware-serde": "^4.2.8", "@smithy/middleware-stack": "^4.2.7", "@smithy/node-config-provider": "^4.3.7", "@smithy/node-http-handler": "^4.4.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.5", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.19", "@smithy/util-defaults-mode-node": "^4.2.22", "@smithy/util-endpoints": "^3.2.7", "@smithy/util-middleware": "^4.2.7", "@smithy/util-retry": "^4.2.7", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-y+k23MvMzpn1WpeQ9sdEXg1Bbw7dfi0ZH2uwyBv78F/kz0mZOI+RJ1KJg8DgSD8XvdxB8gX5GQ8rzo0LnDothA=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@aws-sdk/xml-builder": "3.968.0", "@smithy/core": "^3.20.3", "@smithy/node-config-provider": "^4.3.7", "@smithy/property-provider": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/signature-v4": "^5.3.7", "@smithy/smithy-client": "^4.10.5", "@smithy/types": "^4.11.0", "@smithy/util-base64": "^4.3.0", "@smithy/util-middleware": "^4.2.7", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-u4lIpvGqMMHZN523/RxW70xNoVXHBXucIWZsxFKc373E6TWYEb16ddFhXTELioS5TU93qkd/6yDQZzI6AAhbkw=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/property-provider": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-G+zgXEniQxBHFtHo+0yImkYutvJZLvWqvkPUP8/cG+IaYg54OY7L/GPIAZJh0U3m0Uepao98NbL15zjM+uplqQ=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/node-http-handler": "^4.4.7", "@smithy/property-provider": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.5", "@smithy/types": "^4.11.0", "@smithy/util-stream": "^4.5.8", "tslib": "^2.6.2" } }, "sha512-79teHBx/EtsNRR3Bq8fQdmMHtUcYwvohm9EwXXFt2Jd3BEOBH872IjIlfKdAvdkM+jW1QeeWOZBAxXGPir7GcQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/credential-provider-env": "3.968.0", "@aws-sdk/credential-provider-http": "3.968.0", "@aws-sdk/credential-provider-login": "3.968.0", "@aws-sdk/credential-provider-process": "3.968.0", "@aws-sdk/credential-provider-sso": "3.968.0", "@aws-sdk/credential-provider-web-identity": "3.968.0", "@aws-sdk/nested-clients": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/credential-provider-imds": "^4.2.7", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-9J9pcweoEN8yG7Qliux1zl9J3DT8X6OLcDN2RVXdTd5xzWBaYlupnUiJzoP6lvXdMnEmlDZaV7IMtoBdG7MY6g=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/nested-clients": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/property-provider": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-YxBaR0IMuHPOVTG+73Ve0QfllweN+EdwBRnHFhUGnahMGAcTmcaRdotqwqWfiws+9ud44IFKjxXR3t8jaGpFnQ=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.968.0", "", { "dependencies": { "@aws-sdk/credential-provider-env": "3.968.0", "@aws-sdk/credential-provider-http": "3.968.0", "@aws-sdk/credential-provider-ini": "3.968.0", "@aws-sdk/credential-provider-process": "3.968.0", "@aws-sdk/credential-provider-sso": "3.968.0", "@aws-sdk/credential-provider-web-identity": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/credential-provider-imds": "^4.2.7", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-wei6v0c9vDEam8pM5eWe9bt+5ixg8nL0q+DFPzI6iwdLUqmJsPoAzWPEyMkgp03iE02SS2fMqPWpmRjz/NVyUw=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-my9M/ijRyEACoyeEWiC2sTVM3+eck5IWPGTPQrlYMKivy4LLlZchohtIopuqTom+JZzLZD508j1s9aDvl7BA0w=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.968.0", "", { "dependencies": { "@aws-sdk/client-sso": "3.968.0", "@aws-sdk/core": "3.968.0", "@aws-sdk/token-providers": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-XPYPcxfWIt5jBbofoP2xhAHlFYos0dzwbHsoE18Cera/XnaCEbsUpdROo30t0Kjdbv0EWMYLMPDi9G+vPRDnhQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/nested-clients": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-9HNAP6mx2jsBW4moWnRg5ycyZ0C1EbtMIegIHa93ga13B/8VZF9Y0iDnwW73yQYzCEt9UrDiFeRck/ChZup3rA=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/eventstream-codec": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-OJ0Vddxq6u7RdFoH7ZgV3O95zlHN4d7F4fgJszBtqVNGczM4jWPrApBX6dvl5uqAhMFSqyTW1Ld0IHKVpiTMjw=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-pDMSJMXkus8mCm+2QiQUQefslLVP0z8VmvPA/sj9Mgv+oAcvMdnBzXwBNlwajtiKXaMMXq1SI2y29nOI8WJCgg=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-ujlNT215VtE/2D2jEhFVcTuPPB36HJyLBM0ytnni/WPIjzq89iJrKR1tEhxpk8uct6A5NSQ6w9Y7g2Rw1rkSoQ=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-zvhhEPZgvaRDxzf27m2WmgaXoN7upFt/gvG7ofBN5zCBlkh3JtFamMh5KWYVQwMhc4eQBK3NjH0oIUKZSVztag=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-KygPiwpSAPGobgodK/oLb7OLiwK29pNJeNtP+GZ9pxpceDRqhN0Ub8Eo84dBbWq+jbzAqBYHzy+B1VsbQ/hLWA=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/types": "3.968.0", "@aws-sdk/util-endpoints": "3.968.0", "@smithy/core": "^3.20.3", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-4h5/B8FyxMjLxtXd5jbM2R69aO57qQiHoAJQTtkpuxmM7vhvjSxEQtMM9L1kuMXoMVNE7xM4886h0+gbmmxplg=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@aws-sdk/util-format-url": "3.968.0", "@smithy/eventstream-codec": "^4.2.7", "@smithy/eventstream-serde-browser": "^4.2.7", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/protocol-http": "^5.3.7", "@smithy/signature-v4": "^5.3.7", "@smithy/types": "^4.11.0", "@smithy/util-hex-encoding": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-GB2w4U4ulTHgA9hScKHErN/9EAmY640UTfOyIKmTrXXtyVMK8XCdfTmFoUnQJtWBBucATWXqo+EavqQML5/cQw=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.968.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "3.968.0", "@aws-sdk/middleware-host-header": "3.968.0", "@aws-sdk/middleware-logger": "3.968.0", "@aws-sdk/middleware-recursion-detection": "3.968.0", "@aws-sdk/middleware-user-agent": "3.968.0", "@aws-sdk/region-config-resolver": "3.968.0", "@aws-sdk/types": "3.968.0", "@aws-sdk/util-endpoints": "3.968.0", "@aws-sdk/util-user-agent-browser": "3.968.0", "@aws-sdk/util-user-agent-node": "3.968.0", "@smithy/config-resolver": "^4.4.5", "@smithy/core": "^3.20.3", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/hash-node": "^4.2.7", "@smithy/invalid-dependency": "^4.2.7", "@smithy/middleware-content-length": "^4.2.7", "@smithy/middleware-endpoint": "^4.4.4", "@smithy/middleware-retry": "^4.4.20", "@smithy/middleware-serde": "^4.2.8", "@smithy/middleware-stack": "^4.2.7", "@smithy/node-config-provider": "^4.3.7", "@smithy/node-http-handler": "^4.4.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.5", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.19", "@smithy/util-defaults-mode-node": "^4.2.22", "@smithy/util-endpoints": "^3.2.7", "@smithy/util-middleware": "^4.2.7", "@smithy/util-retry": "^4.2.7", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-LLppm+8MzD3afD2IA/tYDp5AoVPOybK7MHQz5DVB4HsZ+fHvwYlvau2ZUK8nKwJSk5c1kWcxCZkyuJQjFu37ng=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/config-resolver": "^4.4.5", "@smithy/node-config-provider": "^4.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-BzrCpxEsAHbi+yDGtgXJ+/5AvLPjfhcT6DlL+Fc4g13J5Z0VwiO95Wem+Q4KK7WDZH7/sZ/1WFvfitjLTKZbEw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.968.0", "", { "dependencies": { "@aws-sdk/core": "3.968.0", "@aws-sdk/nested-clients": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-lXUZqB2qTFmZYNXPnVT0suSHGiuQAPrL2DhmhbjqOdR7+GKDHL5KbeKFvPisy7Y4neliJqT4Q1VPWa0nqYaiZg=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.968.0", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-Wuumj/1cuiuXTMdHmvH88zbEl+5Pw++fOFQuMCF4yP0R+9k1lwX8rVst+oy99xaxtdluJZXrsccoZoA67ST1Ow=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-endpoints": "^3.2.7", "tslib": "^2.6.2" } }, "sha512-9IdilgylS0crFSeI59vtr8qhDYMYYOvnvkl1dLp59+EmLH1IdXz7+4cR5oh5PkoqD7DRzc5Uzm2GnZhK6I0oVQ=="],
+
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/querystring-builder": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-tJZuMKOJNCjrSh3+TS1brR4pW2W/O5mVkbKERJfO7BOhyV2+819QAoCX5a9Jy3AOHyMWddCpHmXaz6y2a3avWA=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-qKgO7wAYsXzhwCHhdbaKFyxd83Fgs8/1Ka+jjSPrv2Ll7mB55Wbwlo0kkfMLh993/yEc8aoDIAc1Fz9h4Spi4Q=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.968.0", "", { "dependencies": { "@aws-sdk/types": "3.968.0", "@smithy/types": "^4.11.0", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-nRxjs8Jpq8ZHFsa/0uiww2f4+40D6Dt6bQmepAJHIE/D+atwPINDKsfamCjFnxrjKU3WBWpGYEf/QDO0XZsFMw=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.968.0", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "3.968.0", "@aws-sdk/types": "3.968.0", "@smithy/node-config-provider": "^4.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-oaIkPGraGhZgkDmxVhTIlakaUNWKO9aMN+uB6I+eS26MWi/lpMK66HTZeXEnaTrmt5/kl99YC0N37zScz58Tdg=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.968.0", "", { "dependencies": { "@smithy/types": "^4.11.0", "fast-xml-parser": "5.2.5", "tslib": "^2.6.2" } }, "sha512-bZQKn41ebPh/uW9uWUE5oLuaBr44Gt78dkw2amu5zcwo1J/d8s6FdzZcRDmz0rHE2NHJWYkdQYeVQo7jhMziqA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
+    "@google/genai": ["@google/genai@1.34.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw=="],
+
+    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
+
+    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.0", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.0", "@mariozechner/clipboard-darwin-universal": "0.3.0", "@mariozechner/clipboard-darwin-x64": "0.3.0", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.0", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.0", "@mariozechner/clipboard-linux-x64-gnu": "0.3.0", "@mariozechner/clipboard-linux-x64-musl": "0.3.0", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.0", "@mariozechner/clipboard-win32-x64-msvc": "0.3.0" } }, "sha512-tQrCRAtr58BLmWcvwCqlJo5GJgqBGb3zwOBFFBKCEKvRgD8y/EawhCyXsfOh9XOOde1NTAYsYuYyVOYw2tLnoQ=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7i4bitLzRSij0fj6q6tPmmf+JrwHqfBsBmf8mOcLVv0LVexD+4gEsyMait4i92exKYmCfna6uHKVS84G4nqehg=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.0", "", { "os": "darwin" }, "sha512-FVZLGdIkmvqtPQjD0GQwKLVheL+zV7DjA6I5NcsHGjBeWpG2nACS6COuelNf8ruMoPxJFw7RoB4fjw6mmjT+Nw=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-KuurQYEqRhalvBji3CH5xIq1Ts23IgVRE3rjanhqFDI77luOhCnlNbDtqv3No5OxJhEBLykQNrAzfgjqPsPWdA=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-nWpGMlk43bch7ztGfnALcSi5ZREVziPYzrFKjoJimbwaiULrfY0fGce0gWBynP9ak0nHgDLp0nSa7b4cCl+cIw=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.0", "", { "os": "linux", "cpu": "none" }, "sha512-4BC08CIaOXSSAGRZLEjqJmQfioED8ohAzwt0k2amZPEbH96YKoBNorq5EdwPf5VT+odS0DeyCwhwtxokRLZIvQ=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GpNY5Y9nOzr0Vt0Qi5U88qwe6piiIHk44kSMexl8ns90LluN5UTNYmyfi7Xq3/lmPZCpnB2xvBTYbsXCxnopIA=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+PnR48/x9GMY5Kh8BLjzHMx6trOegMtxAuqTM9X/bhV3QuW6sLLd7nojDHSGj/ZueK6i0tcQxvOrgNLozVtNDA=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-+dy2vZ1Ph4EYj0cotB+bVUVk/uKl2bh9LOp/zlnFqoCCYDN6sm+L0VyIOPPo3hjoEVdGpHe1MUxp3qG/OLwXgg=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dfpHrUpKHl7ad3xVGE1+gIN3cEnjjPZa4I0BIYMuj2OKq07Gf1FKTXMypB41rDFv6XNzcfhYQnY+ZNgIu9FB8A=="],
+
+    "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
+
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.45.6", "", { "dependencies": { "@mariozechner/pi-ai": "^0.45.6", "@mariozechner/pi-tui": "^0.45.6" } }, "sha512-03nczMho59HvbNkFcct+Fj7Eb1+rLV3IESdG4Viv9pJ5eWM61afdF9SIDlJoVUDF6JY1UM0UdJQb/Mxlo2JL3A=="],
+
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.45.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.71.2", "@aws-sdk/client-bedrock-runtime": "^3.966.0", "@google/genai": "1.34.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-AtKx0XUjd2cJPucrDTd/GbCNzCYW612SpGanFD5gzFvMBKBlT4Br4tW+E0rOocFO0oydvWyACaKLGamQqUCfdQ=="],
+
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.45.6", "", { "dependencies": { "@mariozechner/clipboard": "^0.3.0", "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.45.6", "@mariozechner/pi-ai": "^0.45.6", "@mariozechner/pi-tui": "^0.45.6", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "file-type": "^21.1.1", "glob": "^11.0.3", "marked": "^15.0.12", "minimatch": "^10.1.1", "proper-lockfile": "^4.1.2", "wasm-vips": "^0.0.16" }, "bin": { "pi": "dist/cli.js" } }, "sha512-pJt74By9sGEvwJTj/A6KiQUtvBMHWpyiU7CNEkpa0xPL6zZR8kPiBgmG5HVtieEnLOH1TM9UHM69H968aFNpzA=="],
+
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.45.6", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-rNakULPahABwp4pFobwLjZYa3pvArgXqEU6xQRW8wvh6N6st+W+qDXZR3B7+1S5ZQ/kZ83gTT8+wP4e21Nn6Vw=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@1.10.0", "", { "dependencies": { "zod": "^3.20.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.47", "", {}, "sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw=="],
+
+    "@smithy/abort-controller": ["@smithy/abort-controller@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.6", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.8", "@smithy/types": "^4.12.0", "@smithy/util-config-provider": "^4.2.0", "@smithy/util-endpoints": "^3.2.8", "@smithy/util-middleware": "^4.2.8", "tslib": "^2.6.2" } }, "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ=="],
+
+    "@smithy/core": ["@smithy/core@3.20.5", "", { "dependencies": { "@smithy/middleware-serde": "^4.2.9", "@smithy/protocol-http": "^5.3.8", "@smithy/types": "^4.12.0", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-middleware": "^4.2.8", "@smithy/util-stream": "^4.5.10", "@smithy/util-utf8": "^4.2.0", "@smithy/uuid": "^1.1.0", "tslib": "^2.6.2" } }, "sha512-0Tz77Td8ynHaowXfOdrD0F1IH4tgWGUhwmLwmpFyTbr+U9WHXNNp9u/k2VjBXGnSe7BwjBERRpXsokGTXzNjhA=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.8", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.8", "@smithy/property-provider": "^4.2.8", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "tslib": "^2.6.2" } }, "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.8", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.12.0", "@smithy/util-hex-encoding": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw=="],
+
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.8", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw=="],
+
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.3.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ=="],
+
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.2.8", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A=="],
+
+    "@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.8", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.9", "", { "dependencies": { "@smithy/protocol-http": "^5.3.8", "@smithy/querystring-builder": "^4.2.8", "@smithy/types": "^4.12.0", "@smithy/util-base64": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "@smithy/util-buffer-from": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.8", "", { "dependencies": { "@smithy/protocol-http": "^5.3.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.6", "", { "dependencies": { "@smithy/core": "^3.20.5", "@smithy/middleware-serde": "^4.2.9", "@smithy/node-config-provider": "^4.3.8", "@smithy/shared-ini-file-loader": "^4.4.3", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-middleware": "^4.2.8", "tslib": "^2.6.2" } }, "sha512-dpq3bHqbEOBqGBjRVHVFP3eUSPpX0BYtg1D5d5Irgk6orGGAuZfY22rC4sErhg+ZfY/Y0kPqm1XpAmDZg7DeuA=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.4.22", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.8", "@smithy/protocol-http": "^5.3.8", "@smithy/service-error-classification": "^4.2.8", "@smithy/smithy-client": "^4.10.7", "@smithy/types": "^4.12.0", "@smithy/util-middleware": "^4.2.8", "@smithy/util-retry": "^4.2.8", "@smithy/uuid": "^1.1.0", "tslib": "^2.6.2" } }, "sha512-vwWDMaObSMjw6WCC/3Ae9G7uul5Sk95jr07CDk1gkIMpaDic0phPS1MpVAZ6+YkF7PAzRlpsDjxPwRlh/S11FQ=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.9", "", { "dependencies": { "@smithy/protocol-http": "^5.3.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.8", "", { "dependencies": { "@smithy/property-provider": "^4.2.8", "@smithy/shared-ini-file-loader": "^4.4.3", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.4.8", "", { "dependencies": { "@smithy/abort-controller": "^4.2.8", "@smithy/protocol-http": "^5.3.8", "@smithy/querystring-builder": "^4.2.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-q9u+MSbJVIJ1QmJ4+1u+cERXkrhuILCBDsJUBAW1MPE6sFonbCNaegFuwW9ll8kh5UdyY3jOkoOGlc7BesoLpg=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ=="],
+
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "@smithy/util-uri-escape": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw=="],
+
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA=="],
+
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0" } }, "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.3", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.8", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.0", "@smithy/protocol-http": "^5.3.8", "@smithy/types": "^4.12.0", "@smithy/util-hex-encoding": "^4.2.0", "@smithy/util-middleware": "^4.2.8", "@smithy/util-uri-escape": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.10.7", "", { "dependencies": { "@smithy/core": "^3.20.5", "@smithy/middleware-endpoint": "^4.4.6", "@smithy/middleware-stack": "^4.2.8", "@smithy/protocol-http": "^5.3.8", "@smithy/types": "^4.12.0", "@smithy/util-stream": "^4.5.10", "tslib": "^2.6.2" } }, "sha512-Uznt0I9z3os3Z+8pbXrOSCTXCA6vrjyN7Ub+8l2pRDum44vLv8qw0qGVkJN0/tZBZotaEFHrDPKUoPNueTr5Vg=="],
+
+    "@smithy/types": ["@smithy/types@4.12.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.8", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.2.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.21", "", { "dependencies": { "@smithy/property-provider": "^4.2.8", "@smithy/smithy-client": "^4.10.7", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-DtmVJarzqtjghtGjCw/PFJolcJkP7GkZgy+hWTAN3YLXNH+IC82uMoMhFoC3ZtIz5mOgCm5+hOGi1wfhVYgrxw=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.24", "", { "dependencies": { "@smithy/config-resolver": "^4.4.6", "@smithy/credential-provider-imds": "^4.2.8", "@smithy/node-config-provider": "^4.3.8", "@smithy/property-provider": "^4.2.8", "@smithy/smithy-client": "^4.10.7", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-JelBDKPAVswVY666rezBvY6b0nF/v9TXjUbNwDNAyme7qqKYEX687wJv0uze8lBIZVbg30wlWnlYfVSjjpKYFA=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.2.8", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.2.8", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.10", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.9", "@smithy/node-http-handler": "^4.4.8", "@smithy/types": "^4.12.0", "@smithy/util-base64": "^4.3.0", "@smithy/util-buffer-from": "^4.2.0", "@smithy/util-hex-encoding": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g=="],
+
+    "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw=="],
+
+    "@smithy/uuid": ["@smithy/uuid@1.1.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+
+    "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
+
+    "@types/node": ["@types/node@25.0.8", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bowser": ["bowser@2.13.1", "", {}, "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="],
+
+    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
+    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.2.5", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
+
+    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "openai": ["openai@6.10.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
+
+    "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "wasm-vips": ["wasm-vips@0.0.16", "", {}, "sha512-4/bEq8noAFt7DX3VT+Vt5AgNtnnOLwvmrDbduWfiv9AV+VYkbUU4f9Dam9e6khRqPinyClFHCqiwATTTJEiGwA=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
+    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "rimraf/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+  }
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pi-server",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build --compile src/index.ts --outfile dist/pi-server && cp node_modules/@mariozechner/pi-coding-agent/package.json dist/",
+    "start": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "dependencies": {
+    "@mariozechner/pi-coding-agent": "^0.45.5",
+    "hono": "^4"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.11",
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -1,0 +1,105 @@
+/**
+ * Server configuration and data directory resolution.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export interface ServerConfig {
+  port: number;
+  host: string; // Use "::" for dual-stack (IPv4 + IPv6)
+  dataDir: string;
+}
+
+/**
+ * Get the data directory following XDG spec.
+ * Priority: CLI arg > env var > XDG_DATA_HOME > ~/.local/share
+ */
+export function getDataDir(override?: string): string {
+  if (override) return override;
+
+  if (process.env.PI_SERVER_DATA_DIR) {
+    return process.env.PI_SERVER_DATA_DIR;
+  }
+
+  const xdgDataHome = process.env.XDG_DATA_HOME;
+  if (xdgDataHome) {
+    return join(xdgDataHome, "pi-server");
+  }
+
+  const home = process.env.HOME;
+  if (!home) {
+    throw new Error("HOME environment variable not set");
+  }
+
+  return join(home, ".local", "share", "pi-server");
+}
+
+/**
+ * Ensure all required data directories exist.
+ */
+export function ensureDataDirs(dataDir: string): void {
+  const dirs = [dataDir, join(dataDir, "sessions"), join(dataDir, "worktrees")];
+
+  for (const dir of dirs) {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+}
+
+/**
+ * Parse CLI arguments.
+ */
+export function parseArgs(args: string[]): ServerConfig {
+  let port = parseInt(process.env.PI_SERVER_PORT || "3000", 10);
+  let host = "::";
+  let dataDir: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === "--port" || arg === "-p") {
+      port = parseInt(args[++i], 10);
+      if (Number.isNaN(port)) {
+        throw new Error(`Invalid port: ${args[i]}`);
+      }
+    } else if (arg === "--host") {
+      host = args[++i];
+    } else if (arg === "--data-dir") {
+      dataDir = args[++i];
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  return {
+    port,
+    host,
+    dataDir: getDataDir(dataDir),
+  };
+}
+
+function printHelp(): void {
+  console.log(`
+pi-server - WebSocket server for pi coding agent
+
+Usage:
+  pi-server [options]
+
+Options:
+  --port, -p <port>       Listen port (default: 3000, env: PI_SERVER_PORT)
+  --host <host>           Bind host (default: :: for dual-stack)
+  --data-dir <path>       Data directory (env: PI_SERVER_DATA_DIR)
+                          Default: $XDG_DATA_HOME/pi-server or ~/.local/share/pi-server
+  --help, -h              Show this help
+
+Data Directory Structure:
+  <data-dir>/
+    repos.json            Repo definitions
+    sessions/             Pi session files
+    worktrees/            Git worktrees per session
+    state.json            Server state
+`);
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,0 +1,159 @@
+/**
+ * Pi Server - WebSocket server for pi coding agent.
+ *
+ * Provides remote access to pi's AgentSession via WebSocket,
+ * enabling iOS and other remote clients to use the coding agent.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { ServerWebSocket } from "bun";
+import { Hono } from "hono";
+import { ensureDataDirs, parseArgs } from "./config.js";
+import { SessionManager } from "./session/manager.js";
+import { ConnectionManager } from "./ws/connection.js";
+import { type HandlerContext, handleMessage } from "./ws/handler.js";
+
+// WebSocket data type
+interface WSData {
+  connectionId: string;
+}
+
+// Parse CLI arguments
+const config = parseArgs(process.argv.slice(2));
+
+// Ensure data directories exist
+ensureDataDirs(config.dataDir);
+
+// Load .env from data directory if it exists
+const envPath = join(config.dataDir, ".env");
+if (existsSync(envPath)) {
+  const envFile = Bun.file(envPath);
+  const envContent = await envFile.text();
+  for (const line of envContent.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith("#")) {
+      const eqIndex = trimmed.indexOf("=");
+      if (eqIndex > 0) {
+        const key = trimmed.slice(0, eqIndex);
+        let value = trimmed.slice(eqIndex + 1);
+        // Remove surrounding quotes if present
+        if (
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))
+        ) {
+          value = value.slice(1, -1);
+        }
+        process.env[key] = value;
+      }
+    }
+  }
+  console.log(`  Loaded .env from: ${envPath}`);
+}
+
+console.log("Pi Server starting...");
+console.log(`  Data directory: ${config.dataDir}`);
+console.log(`  Listening on: ${config.host}:${config.port}`);
+
+// Initialize managers
+const connectionManager = new ConnectionManager();
+const sessionManager = new SessionManager(config.dataDir);
+
+// Set up session event forwarding
+sessionManager.onEvent((sessionId, event) => {
+  connectionManager.broadcastEvent(sessionId, event.type, event);
+});
+
+// Create Hono app
+const app = new Hono();
+
+// Health check endpoint
+app.get("/health", (c) => {
+  return c.json({ ok: true, version: "0.1.0" });
+});
+
+// Info endpoint
+app.get("/", (c) => {
+  return c.json({
+    name: "pi-server",
+    version: "0.1.0",
+    endpoints: {
+      websocket: "/rpc",
+      health: "/health",
+    },
+  });
+});
+
+// Start Bun server with WebSocket support
+Bun.serve<WSData>({
+  port: config.port,
+  hostname: config.host,
+
+  // HTTP handler (Hono)
+  fetch(req, server) {
+    const url = new URL(req.url);
+
+    // WebSocket upgrade for /rpc
+    if (url.pathname === "/rpc") {
+      // Create connection before upgrade to get ID
+      const connectionId = crypto.randomUUID();
+      const upgraded = server.upgrade(req, { data: { connectionId } });
+      if (!upgraded) {
+        return new Response("WebSocket upgrade failed", { status: 400 });
+      }
+      return undefined;
+    }
+
+    // Regular HTTP requests handled by Hono
+    return app.fetch(req);
+  },
+
+  // WebSocket handlers
+  websocket: {
+    open(ws: ServerWebSocket<WSData>) {
+      const { connectionId } = ws.data;
+      connectionManager.registerConnection(
+        connectionId,
+        ws as unknown as WebSocket,
+      );
+      console.log(`WebSocket connected: ${connectionId}`);
+    },
+
+    async message(ws: ServerWebSocket<WSData>, message) {
+      const { connectionId } = ws.data;
+      const connection = connectionManager.getConnection(connectionId);
+
+      if (!connection) {
+        console.error(`No connection found for ${connectionId}`);
+        return;
+      }
+
+      const data = typeof message === "string" ? message : message.toString();
+      console.log(`[${connectionId.slice(0, 8)}] <- ${data.slice(0, 200)}`);
+
+      const ctx: HandlerContext = {
+        connection,
+        connectionManager,
+        sessionManager,
+        dataDir: config.dataDir,
+      };
+
+      try {
+        await handleMessage(ctx, data);
+      } catch (error) {
+        console.error("Error handling message:", error);
+      }
+    },
+
+    close(ws: ServerWebSocket<WSData>, code, reason) {
+      const { connectionId } = ws.data;
+      connectionManager.removeConnection(connectionId);
+      console.log(
+        `WebSocket disconnected: ${connectionId} (${code}: ${reason})`,
+      );
+    },
+  },
+});
+
+console.log(`Pi Server running at http://${config.host}:${config.port}`);
+console.log(`WebSocket endpoint: ws://${config.host}:${config.port}/rpc`);

--- a/apps/server/src/session/manager.ts
+++ b/apps/server/src/session/manager.ts
@@ -1,0 +1,299 @@
+/**
+ * Session manager - handles AgentSession lifecycle and state persistence.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  AgentSession,
+  AgentSessionEvent,
+} from "@mariozechner/pi-coding-agent";
+import {
+  AuthStorage,
+  createAgentSession,
+  createCodingTools,
+  ModelRegistry,
+  SessionManager as PiSessionManager,
+} from "@mariozechner/pi-coding-agent";
+import { getRepo } from "../repos.js";
+import type { ServerState, SessionInfo } from "../types.js";
+import { createWorktree, deleteWorktree } from "./worktree.js";
+
+export interface ActiveSession {
+  session: AgentSession;
+  info: SessionInfo;
+  repoPath: string;
+  unsubscribe: () => void;
+}
+
+export type SessionEventCallback = (
+  sessionId: string,
+  event: AgentSessionEvent,
+) => void;
+
+/**
+ * Manages all active sessions and their persistence.
+ */
+export class SessionManager {
+  private dataDir: string;
+  private sessions: Map<string, ActiveSession> = new Map();
+  private state: ServerState;
+  private eventCallback?: SessionEventCallback;
+
+  // Shared auth and model registry
+  private authStorage;
+  private modelRegistry;
+
+  constructor(dataDir: string) {
+    this.dataDir = dataDir;
+    this.state = this.loadState();
+
+    // TODO: Replace file-based auth with encrypted storage or system keychain
+    // (macOS Keychain, Linux secret-service, etc.) using setFallbackResolver or custom impl
+    const authPath = join(dataDir, "auth.json");
+    this.authStorage = new AuthStorage(authPath);
+
+    // No custom models.json for now (built-in models only)
+    this.modelRegistry = new ModelRegistry(this.authStorage);
+  }
+
+  private getDefaultModel() {
+    let model = this.modelRegistry.find("mistral", "devstral-2512");
+    if (!model) {
+      model = this.modelRegistry.find("anthropic", "claude-3-5-sonnet-latest");
+    }
+    if (!model) {
+      const available = this.modelRegistry.getAvailable();
+      if (available.length > 0) {
+        model = available[0];
+      }
+    }
+    return model;
+  }
+
+  /**
+   * Set callback for session events.
+   */
+  onEvent(callback: SessionEventCallback): void {
+    this.eventCallback = callback;
+  }
+
+  /**
+   * Create a new session for a repo.
+   */
+  async createSession(repoId: string): Promise<SessionInfo> {
+    const repo = getRepo(this.dataDir, repoId);
+    if (!repo) {
+      throw new Error(`Repo not found: ${repoId}`);
+    }
+
+    const sessionId = crypto.randomUUID();
+    const worktreesDir = join(this.dataDir, "worktrees");
+    const sessionsDir = join(this.dataDir, "sessions");
+
+    // Create worktree
+    const worktreePath = await createWorktree(
+      repo.path,
+      worktreesDir,
+      sessionId,
+    );
+
+    // Create session info
+    const now = new Date().toISOString();
+    const info: SessionInfo = {
+      sessionId,
+      repoId,
+      worktreePath,
+      createdAt: now,
+      lastActivityAt: now,
+    };
+
+    // Find a model to use
+    const model = this.getDefaultModel();
+
+    if (!model) {
+      console.warn("No models found! Session created without a model.");
+    }
+
+    // Create AgentSession
+    const { session } = await createAgentSession({
+      cwd: worktreePath,
+      sessionManager: PiSessionManager.create(worktreePath, sessionsDir),
+      authStorage: this.authStorage,
+      modelRegistry: this.modelRegistry,
+      tools: createCodingTools(worktreePath),
+      model,
+    });
+
+    // Subscribe to events
+    const unsubscribe = session.subscribe((event) => {
+      this.handleSessionEvent(sessionId, event);
+    });
+
+    // Store active session
+    this.sessions.set(sessionId, {
+      session,
+      info,
+      repoPath: repo.path,
+      unsubscribe,
+    });
+
+    // Persist state
+    this.state.sessions[sessionId] = info;
+    this.saveState();
+
+    return info;
+  }
+
+  /**
+   * Get an active session.
+   */
+  getSession(sessionId: string): ActiveSession | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  /**
+   * List all sessions (active and persisted).
+   */
+  listSessions(): SessionInfo[] {
+    return Object.values(this.state.sessions);
+  }
+
+  /**
+   * Resume a persisted session.
+   */
+  async resumeSession(sessionId: string): Promise<ActiveSession> {
+    // Check if already active
+    const existing = this.sessions.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
+    // Load from state
+    const info = this.state.sessions[sessionId];
+    if (!info) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    const repo = getRepo(this.dataDir, info.repoId);
+    if (!repo) {
+      throw new Error(`Repo not found: ${info.repoId}`);
+    }
+
+    // Check if worktree still exists
+    if (!existsSync(info.worktreePath)) {
+      throw new Error(`Worktree not found: ${info.worktreePath}`);
+    }
+
+    const sessionsDir = join(this.dataDir, "sessions");
+
+    // Find a model to use if session doesn't have one restored
+    const model = this.getDefaultModel();
+
+    // Resume AgentSession
+    const { session } = await createAgentSession({
+      cwd: info.worktreePath,
+      sessionManager: PiSessionManager.continueRecent(
+        info.worktreePath,
+        sessionsDir,
+      ),
+      authStorage: this.authStorage,
+      modelRegistry: this.modelRegistry,
+      tools: createCodingTools(info.worktreePath),
+      model, // Provide default model in case restoration fails
+    });
+
+    // Subscribe to events
+    const unsubscribe = session.subscribe((event) => {
+      this.handleSessionEvent(sessionId, event);
+    });
+
+    const activeSession: ActiveSession = {
+      session,
+      info,
+      repoPath: repo.path,
+      unsubscribe,
+    };
+
+    this.sessions.set(sessionId, activeSession);
+
+    // Update last activity
+    info.lastActivityAt = new Date().toISOString();
+    this.saveState();
+
+    return activeSession;
+  }
+
+  /**
+   * Delete a session and its worktree.
+   */
+  async deleteSession(sessionId: string): Promise<void> {
+    const active = this.sessions.get(sessionId);
+    const info = this.state.sessions[sessionId];
+
+    if (active) {
+      // Unsubscribe and dispose
+      active.unsubscribe();
+      active.session.dispose();
+      this.sessions.delete(sessionId);
+
+      // Delete worktree
+      await deleteWorktree(active.repoPath, active.info.worktreePath);
+    } else if (info) {
+      // Not active but persisted - try to delete worktree
+      const repo = getRepo(this.dataDir, info.repoId);
+      if (repo) {
+        await deleteWorktree(repo.path, info.worktreePath);
+      }
+    }
+
+    // Remove from state
+    delete this.state.sessions[sessionId];
+    this.saveState();
+  }
+
+  /**
+   * Update session activity timestamp.
+   */
+  touchSession(sessionId: string): void {
+    const info = this.state.sessions[sessionId];
+    if (info) {
+      info.lastActivityAt = new Date().toISOString();
+      this.saveState();
+    }
+  }
+
+  private handleSessionEvent(
+    sessionId: string,
+    event: AgentSessionEvent,
+  ): void {
+    // Update activity
+    this.touchSession(sessionId);
+
+    // Forward to callback
+    if (this.eventCallback) {
+      this.eventCallback(sessionId, event);
+    }
+  }
+
+  private loadState(): ServerState {
+    const statePath = join(this.dataDir, "state.json");
+
+    if (!existsSync(statePath)) {
+      return { sessions: {} };
+    }
+
+    try {
+      const content = readFileSync(statePath, "utf-8");
+      return JSON.parse(content) as ServerState;
+    } catch (error) {
+      console.error(`Failed to load state.json: ${error}`);
+      return { sessions: {} };
+    }
+  }
+
+  private saveState(): void {
+    const statePath = join(this.dataDir, "state.json");
+    writeFileSync(statePath, JSON.stringify(this.state, null, 2));
+  }
+}

--- a/apps/server/src/session/worktree.ts
+++ b/apps/server/src/session/worktree.ts
@@ -1,0 +1,91 @@
+/**
+ * Git worktree management for session isolation.
+ */
+
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { $ } from "bun";
+
+/**
+ * Create a git worktree for a session.
+ * Returns the path to the worktree.
+ */
+export async function createWorktree(
+  repoPath: string,
+  worktreesDir: string,
+  sessionId: string,
+): Promise<string> {
+  const worktreeName = `wt-${sessionId}`;
+  const worktreePath = join(worktreesDir, worktreeName);
+
+  if (existsSync(worktreePath)) {
+    // Worktree already exists, return it
+    return worktreePath;
+  }
+
+  try {
+    // Get current branch/HEAD
+    const headResult =
+      await $`git -C ${repoPath} rev-parse --abbrev-ref HEAD`.text();
+    const _branch = headResult.trim();
+
+    // Create worktree with detached HEAD at current commit
+    // This avoids branch conflicts
+    const commitResult = await $`git -C ${repoPath} rev-parse HEAD`.text();
+    const commit = commitResult.trim();
+
+    await $`git -C ${repoPath} worktree add --detach ${worktreePath} ${commit}`;
+
+    return worktreePath;
+  } catch (error) {
+    throw new Error(`Failed to create worktree: ${error}`);
+  }
+}
+
+/**
+ * Delete a git worktree.
+ */
+export async function deleteWorktree(
+  repoPath: string,
+  worktreePath: string,
+): Promise<void> {
+  if (!existsSync(worktreePath)) {
+    return;
+  }
+
+  try {
+    // Remove worktree from git
+    await $`git -C ${repoPath} worktree remove ${worktreePath} --force`;
+  } catch (error) {
+    // If git worktree remove fails, try manual cleanup
+    console.warn(`git worktree remove failed, cleaning up manually: ${error}`);
+    try {
+      rmSync(worktreePath, { recursive: true, force: true });
+      // Prune worktree references
+      await $`git -C ${repoPath} worktree prune`;
+    } catch (cleanupError) {
+      console.error(`Manual cleanup failed: ${cleanupError}`);
+    }
+  }
+}
+
+/**
+ * List all worktrees for a repo.
+ */
+export async function listWorktrees(repoPath: string): Promise<string[]> {
+  try {
+    const result = await $`git -C ${repoPath} worktree list --porcelain`.text();
+    const worktrees: string[] = [];
+
+    for (const line of result.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        worktrees.push(line.slice("worktree ".length));
+      }
+    }
+
+    return worktrees;
+  } catch (error) {
+    console.error(`Failed to list worktrees: ${error}`);
+    return [];
+  }
+}

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Protocol types matching pi-core Swift definitions.
+ * WebSocket message envelopes for client-server communication.
+ */
+
+export const PROTOCOL_VERSION = 1;
+
+// Message kinds
+export type WSMessageKind = "request" | "response" | "event";
+
+// Client -> Server request
+export interface WSRequest {
+  v: number;
+  kind: "request";
+  id: string;
+  sessionId?: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+// Server -> Client response
+export interface WSResponse {
+  v: number;
+  kind: "response";
+  id: string;
+  sessionId?: string;
+  ok: boolean;
+  result?: unknown;
+  error?: RPCError;
+}
+
+// Server -> Client event
+export interface WSEvent {
+  v: number;
+  kind: "event";
+  sessionId: string;
+  seq: number;
+  type: string;
+  payload?: unknown;
+}
+
+export interface RPCError {
+  code?: string;
+  message: string;
+  details?: string;
+}
+
+// Hello handshake
+export interface HelloParams {
+  client: ClientInfo;
+  resume?: ResumeInfo;
+}
+
+export interface ClientInfo {
+  name: string;
+  version: string;
+}
+
+export interface ResumeInfo {
+  connectionId: string;
+  lastSeqBySession: Record<string, number>;
+}
+
+export interface HelloResult {
+  connectionId: string;
+  server: ServerInfo;
+  capabilities: ServerCapabilities;
+}
+
+export interface ServerInfo {
+  name: string;
+  version: string;
+}
+
+export interface ServerCapabilities {
+  resume: boolean;
+  replayWindowSec?: number;
+}
+
+// Repo types
+export interface RepoConfig {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface ReposConfig {
+  repos: RepoConfig[];
+}
+
+// Session types
+export interface SessionInfo {
+  sessionId: string;
+  repoId: string;
+  worktreePath: string;
+  createdAt: string;
+  lastActivityAt: string;
+}
+
+export interface ServerState {
+  sessions: Record<string, SessionInfo>;
+}
+
+// Incoming message (for parsing)
+export interface WSIncomingMessage {
+  v?: number;
+  kind?: WSMessageKind;
+  id?: string;
+  sessionId?: string;
+  method?: string;
+  params?: Record<string, unknown>;
+}

--- a/apps/server/src/ws/connection.ts
+++ b/apps/server/src/ws/connection.ts
@@ -1,0 +1,244 @@
+/**
+ * WebSocket connection state management.
+ * Handles hello/resume, seq tracking, and event buffering.
+ */
+
+import type {
+  HelloParams,
+  HelloResult,
+  ResumeInfo,
+  WSEvent,
+  WSResponse,
+} from "../types.js";
+
+const REPLAY_WINDOW_SEC = 60;
+const MAX_BUFFERED_EVENTS = 1000;
+
+interface BufferedEvent {
+  event: WSEvent;
+  timestamp: number;
+}
+
+/**
+ * Represents a single WebSocket connection.
+ */
+export class Connection {
+  readonly connectionId: string;
+  private ws: WebSocket;
+  private attachedSessions: Set<string> = new Set();
+  private seqBySession: Map<string, number> = new Map();
+
+  constructor(connectionId: string, ws: WebSocket) {
+    this.connectionId = connectionId;
+    this.ws = ws;
+  }
+
+  /**
+   * Attach to a session to receive its events.
+   */
+  attach(sessionId: string): void {
+    this.attachedSessions.add(sessionId);
+    if (!this.seqBySession.has(sessionId)) {
+      this.seqBySession.set(sessionId, 0);
+    }
+  }
+
+  /**
+   * Detach from a session.
+   */
+  detach(sessionId: string): void {
+    this.attachedSessions.delete(sessionId);
+  }
+
+  /**
+   * Check if attached to a session.
+   */
+  isAttached(sessionId: string): boolean {
+    return this.attachedSessions.has(sessionId);
+  }
+
+  /**
+   * Get next seq number for a session.
+   */
+  nextSeq(sessionId: string): number {
+    const current = this.seqBySession.get(sessionId) ?? 0;
+    const next = current + 1;
+    this.seqBySession.set(sessionId, next);
+    return next;
+  }
+
+  /**
+   * Get last seq for resume info.
+   */
+  getLastSeqBySession(): Record<string, number> {
+    const result: Record<string, number> = {};
+    for (const [sessionId, seq] of this.seqBySession) {
+      result[sessionId] = seq;
+    }
+    return result;
+  }
+
+  /**
+   * Send a response.
+   */
+  sendResponse(response: WSResponse): void {
+    if (this.ws.readyState === WebSocket.OPEN) {
+      const json = JSON.stringify(response);
+      console.log(
+        `[${this.connectionId.slice(0, 8)}] -> ${json.slice(0, 200)}`,
+      );
+      this.ws.send(json);
+    }
+  }
+
+  /**
+   * Send an event.
+   */
+  sendEvent(event: WSEvent): void {
+    if (this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(event));
+    }
+  }
+
+  /**
+   * Check if connection is open.
+   */
+  get isOpen(): boolean {
+    return this.ws.readyState === WebSocket.OPEN;
+  }
+}
+
+/**
+ * Manages all active connections and event buffering for resume.
+ */
+export class ConnectionManager {
+  private connections: Map<string, Connection> = new Map();
+  private eventBuffers: Map<string, BufferedEvent[]> = new Map();
+
+  /**
+   * Register a new connection with a pre-assigned ID.
+   */
+  registerConnection(connectionId: string, ws: WebSocket): Connection {
+    const connection = new Connection(connectionId, ws);
+    this.connections.set(connectionId, connection);
+    return connection;
+  }
+
+  /**
+   * Get a connection by ID.
+   */
+  getConnection(connectionId: string): Connection | undefined {
+    return this.connections.get(connectionId);
+  }
+
+  /**
+   * Remove a connection.
+   */
+  removeConnection(connectionId: string): void {
+    this.connections.delete(connectionId);
+  }
+
+  /**
+   * Handle hello with optional resume.
+   */
+  handleHello(connection: Connection, params: HelloParams): HelloResult {
+    const result: HelloResult = {
+      connectionId: connection.connectionId,
+      server: {
+        name: "pi-server",
+        version: "0.1.0",
+      },
+      capabilities: {
+        resume: true,
+        replayWindowSec: REPLAY_WINDOW_SEC,
+      },
+    };
+
+    // Handle resume
+    if (params.resume) {
+      this.replayEvents(connection, params.resume);
+    }
+
+    return result;
+  }
+
+  /**
+   * Buffer an event for a session (for resume).
+   */
+  bufferEvent(sessionId: string, event: WSEvent): void {
+    let buffer = this.eventBuffers.get(sessionId);
+    if (!buffer) {
+      buffer = [];
+      this.eventBuffers.set(sessionId, buffer);
+    }
+
+    buffer.push({
+      event,
+      timestamp: Date.now(),
+    });
+
+    // Trim old events
+    const cutoff = Date.now() - REPLAY_WINDOW_SEC * 1000;
+    while (buffer.length > 0 && buffer[0].timestamp < cutoff) {
+      buffer.shift();
+    }
+
+    // Trim by count
+    while (buffer.length > MAX_BUFFERED_EVENTS) {
+      buffer.shift();
+    }
+  }
+
+  /**
+   * Broadcast an event to all connections attached to a session.
+   */
+  broadcastEvent(sessionId: string, type: string, payload: unknown): void {
+    for (const connection of this.connections.values()) {
+      if (connection.isAttached(sessionId) && connection.isOpen) {
+        const seq = connection.nextSeq(sessionId);
+        const event: WSEvent = {
+          v: 1,
+          kind: "event",
+          sessionId,
+          seq,
+          type,
+          payload,
+        };
+
+        connection.sendEvent(event);
+        this.bufferEvent(sessionId, event);
+      }
+    }
+  }
+
+  /**
+   * Replay missed events on resume.
+   */
+  private replayEvents(connection: Connection, resumeInfo: ResumeInfo): void {
+    for (const [sessionId, lastSeq] of Object.entries(
+      resumeInfo.lastSeqBySession,
+    )) {
+      const buffer = this.eventBuffers.get(sessionId);
+      if (!buffer) continue;
+
+      // Re-attach to session
+      connection.attach(sessionId);
+
+      // Find events after lastSeq
+      for (const { event } of buffer) {
+        if (event.seq > lastSeq) {
+          connection.sendEvent(event);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get all connections attached to a session.
+   */
+  getSessionConnections(sessionId: string): Connection[] {
+    return Array.from(this.connections.values()).filter((c) =>
+      c.isAttached(sessionId),
+    );
+  }
+}

--- a/apps/server/src/ws/handler.ts
+++ b/apps/server/src/ws/handler.ts
@@ -1,0 +1,338 @@
+/**
+ * WebSocket message handler.
+ * Routes incoming requests to appropriate handlers.
+ */
+
+import { loadRepos } from "../repos.js";
+import type { SessionManager } from "../session/manager.js";
+import type { HelloParams, WSIncomingMessage, WSResponse } from "../types.js";
+import type { Connection, ConnectionManager } from "./connection.js";
+
+export interface HandlerContext {
+  connection: Connection;
+  connectionManager: ConnectionManager;
+  sessionManager: SessionManager;
+  dataDir: string;
+}
+
+type MethodHandler = (
+  ctx: HandlerContext,
+  params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+) => Promise<unknown>;
+
+const methodHandlers: Record<string, MethodHandler> = {
+  hello: handleHello,
+  "repos.list": handleReposList,
+  "session.create": handleSessionCreate,
+  "session.list": handleSessionList,
+  "session.attach": handleSessionAttach,
+  "session.delete": handleSessionDelete,
+  prompt: handlePrompt,
+  abort: handleAbort,
+  get_state: handleGetState,
+  get_messages: handleGetMessages,
+  get_available_models: handleGetAvailableModels,
+  set_model: handleSetModel,
+};
+
+/**
+ * Handle an incoming WebSocket message.
+ */
+export async function handleMessage(
+  ctx: HandlerContext,
+  data: string,
+): Promise<void> {
+  let message: WSIncomingMessage;
+
+  try {
+    message = JSON.parse(data) as WSIncomingMessage;
+  } catch (_error) {
+    ctx.connection.sendResponse(
+      makeErrorResponse("", "parse_error", "Invalid JSON"),
+    );
+    return;
+  }
+
+  // Validate it's a request
+  if (message.kind !== "request" || !message.method || !message.id) {
+    ctx.connection.sendResponse(
+      makeErrorResponse(
+        message.id ?? "",
+        "invalid_request",
+        "Missing required fields",
+      ),
+    );
+    return;
+  }
+
+  const handler = methodHandlers[message.method];
+  if (!handler) {
+    ctx.connection.sendResponse(
+      makeErrorResponse(
+        message.id,
+        "unknown_method",
+        `Unknown method: ${message.method}`,
+      ),
+    );
+    return;
+  }
+
+  try {
+    const result = await handler(ctx, message.params, message.sessionId);
+    ctx.connection.sendResponse({
+      v: 1,
+      kind: "response",
+      id: message.id,
+      sessionId: message.sessionId,
+      ok: true,
+      result,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    ctx.connection.sendResponse(
+      makeErrorResponse(message.id, "handler_error", errorMessage),
+    );
+  }
+}
+
+function makeErrorResponse(
+  id: string,
+  code: string,
+  message: string,
+): WSResponse {
+  return {
+    v: 1,
+    kind: "response",
+    id,
+    ok: false,
+    error: { code, message },
+  };
+}
+
+// --- Method Handlers ---
+
+async function handleHello(
+  ctx: HandlerContext,
+  params: Record<string, unknown> | undefined,
+): Promise<unknown> {
+  const helloParams = params as HelloParams | undefined;
+  if (!helloParams?.client) {
+    throw new Error("Missing client info");
+  }
+
+  return ctx.connectionManager.handleHello(ctx.connection, helloParams);
+}
+
+async function handleReposList(ctx: HandlerContext): Promise<unknown> {
+  const config = loadRepos(ctx.dataDir);
+  return { repos: config.repos };
+}
+
+async function handleSessionCreate(
+  ctx: HandlerContext,
+  params: Record<string, unknown> | undefined,
+): Promise<unknown> {
+  const repoId = params?.repoId as string | undefined;
+  if (!repoId) {
+    throw new Error("Missing repoId");
+  }
+
+  const info = await ctx.sessionManager.createSession(repoId);
+
+  // Auto-attach the creating connection
+  ctx.connection.attach(info.sessionId);
+
+  return { sessionId: info.sessionId };
+}
+
+async function handleSessionList(ctx: HandlerContext): Promise<unknown> {
+  const sessions = ctx.sessionManager.listSessions();
+  return { sessions };
+}
+
+async function handleSessionAttach(
+  ctx: HandlerContext,
+  params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+): Promise<unknown> {
+  const targetSessionId = (params?.sessionId as string) ?? sessionId;
+  if (!targetSessionId) {
+    throw new Error("Missing sessionId");
+  }
+
+  // Resume session if not active
+  await ctx.sessionManager.resumeSession(targetSessionId);
+
+  // Attach connection
+  ctx.connection.attach(targetSessionId);
+
+  return { ok: true };
+}
+
+async function handleSessionDelete(
+  ctx: HandlerContext,
+  params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+): Promise<unknown> {
+  const targetSessionId = (params?.sessionId as string) ?? sessionId;
+  if (!targetSessionId) {
+    throw new Error("Missing sessionId");
+  }
+
+  await ctx.sessionManager.deleteSession(targetSessionId);
+
+  return { ok: true };
+}
+
+async function handlePrompt(
+  ctx: HandlerContext,
+  params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+): Promise<unknown> {
+  if (!sessionId) {
+    throw new Error("Missing sessionId");
+  }
+
+  const message = params?.message as string | undefined;
+  if (!message) {
+    throw new Error("Missing message");
+  }
+
+  const active = ctx.sessionManager.getSession(sessionId);
+  if (!active) {
+    throw new Error(`Session not active: ${sessionId}`);
+  }
+
+  // Don't await - prompt runs async, events stream back
+  active.session.prompt(message).catch((error) => {
+    console.error(`Prompt error for session ${sessionId}:`, error);
+  });
+
+  return { ok: true };
+}
+
+async function handleAbort(
+  ctx: HandlerContext,
+  _params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+): Promise<unknown> {
+  if (!sessionId) {
+    throw new Error("Missing sessionId");
+  }
+
+  const active = ctx.sessionManager.getSession(sessionId);
+  if (!active) {
+    throw new Error(`Session not active: ${sessionId}`);
+  }
+
+  await active.session.abort();
+
+  return { ok: true };
+}
+
+async function handleGetState(
+  ctx: HandlerContext,
+  _params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+): Promise<unknown> {
+  if (!sessionId) {
+    throw new Error("Missing sessionId");
+  }
+
+  const active = ctx.sessionManager.getSession(sessionId);
+  if (!active) {
+    throw new Error(`Session not active: ${sessionId}`);
+  }
+
+  const session = active.session;
+
+  return {
+    model: session.model,
+    thinkingLevel: session.thinkingLevel,
+    isStreaming: session.isStreaming,
+    sessionId: session.sessionId,
+    sessionFile: session.sessionFile,
+    messageCount: session.messages.length,
+  };
+}
+
+async function handleGetMessages(
+  ctx: HandlerContext,
+  _params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+): Promise<unknown> {
+  if (!sessionId) {
+    throw new Error("Missing sessionId");
+  }
+
+  const active = ctx.sessionManager.getSession(sessionId);
+  if (!active) {
+    throw new Error(`Session not active: ${sessionId}`);
+  }
+
+  return { messages: active.session.messages };
+}
+
+async function handleGetAvailableModels(ctx: HandlerContext): Promise<unknown> {
+  // Get from first active session's model registry, or create temporary one
+  const sessions = Array.from(ctx.sessionManager.listSessions());
+  if (sessions.length === 0) {
+    // No sessions, need to get models differently
+    const { discoverAuthStorage, discoverModels } = await import(
+      "@mariozechner/pi-coding-agent"
+    );
+    const authStorage = discoverAuthStorage();
+    const modelRegistry = discoverModels(authStorage);
+    const models = await modelRegistry.getAvailable();
+    return { models };
+  }
+
+  // Use the session manager's registry (accessed via a session)
+  const firstSession = ctx.sessionManager.getSession(sessions[0].sessionId);
+  if (firstSession) {
+    // The model is available on session.model, but we need the full list
+    // For now, just return the current model info
+    const model = firstSession.session.model;
+    return { models: model ? [model] : [] };
+  }
+
+  return { models: [] };
+}
+
+async function handleSetModel(
+  ctx: HandlerContext,
+  params: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+): Promise<unknown> {
+  if (!sessionId) {
+    throw new Error("Missing sessionId");
+  }
+
+  const provider = params?.provider as string | undefined;
+  const modelId = params?.modelId as string | undefined;
+  if (!provider || !modelId) {
+    throw new Error("Missing provider or modelId");
+  }
+
+  const active = ctx.sessionManager.getSession(sessionId);
+  if (!active) {
+    throw new Error(`Session not active: ${sessionId}`);
+  }
+
+  // Find and set model
+  const { discoverAuthStorage, discoverModels } = await import(
+    "@mariozechner/pi-coding-agent"
+  );
+  const authStorage = discoverAuthStorage();
+  const modelRegistry = discoverModels(authStorage);
+  const model = modelRegistry.find(provider, modelId);
+
+  if (!model) {
+    throw new Error(`Model not found: ${provider}/${modelId}`);
+  }
+
+  await active.session.setModel(model);
+
+  return { model };
+}

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
               swiftlintWrapper
               pkgs.xcodegen
               pkgs.gnumake
+              pkgs.bun
             ];
 
             shellHook = ''
@@ -66,11 +67,15 @@
               echo "Pi Apps Development Environment"
               echo "================================"
               echo ""
-              echo "Quick start:"
+              echo "Desktop/Mobile (Swift):"
               echo "  make setup    - First-time setup"
               echo "  make xcode    - Open in Xcode"
               echo "  make build    - Build from command line"
-              echo "  make help     - Show all commands"
+              echo ""
+              echo "Server (TypeScript/Bun):"
+              echo "  cd apps/server && bun install"
+              echo "  bun run dev   - Run with hot reload"
+              echo "  bun run build - Build standalone binary"
               echo ""
             '';
           };

--- a/packages/pi-core/Sources/PiCore/Transport/RPCConnection.swift
+++ b/packages/pi-core/Sources/PiCore/Transport/RPCConnection.swift
@@ -285,7 +285,10 @@ public actor RPCConnection {
 
     /// Parse AssistantMessageEvent from a dictionary
     private func parseAssistantMessageEvent(from dict: [String: Any]) -> AssistantMessageEvent {
-        let eventDict = dict["event"] as? [String: Any] ?? dict
+        // Server sends "assistantMessageEvent", legacy sends "event"
+        let eventDict = dict["assistantMessageEvent"] as? [String: Any]
+            ?? dict["event"] as? [String: Any]
+            ?? dict
         let eventType = eventDict["type"] as? String ?? ""
 
         switch eventType {


### PR DESCRIPTION
## Summary

Adds a WebSocket server (`apps/server/`) that runs the pi coding agent via the SDK, enabling iOS clients to use pi remotely.

## Features

- **Server** (TypeScript/Bun)
  - WebSocket RPC server using Hono
  - Session management with git worktrees for isolation
  - Auto-selects model (devstral-2512 > claude-3-5-sonnet > first available)
  - Compiles to standalone binary
  - XDG-compliant data directory

- **iOS Client Updates**
  - WebSocketTransport for server communication
  - Event streaming (agent responses, tool execution)
  - Session create/attach/delete flow
  - Server URL configuration

## Protocol

```
hello → repos.list → session.create → session.attach → prompt
```

Events stream back: agent_start, message_update (text_delta), tool_execution_*, agent_end

## Usage

```bash
# Server
cd apps/server && bun install
bun run dev -- --data-dir /path/to/data

# Data dir needs:
# - repos.json (repo definitions)
# - auth.json (API keys, can symlink from ~/.pi/agent/)
```

## TODO

- [ ] Encrypted auth storage (currently file-based)
- [ ] Better error handling in UI
- [ ] Session resume on reconnect
- [ ] Tool execution UI