### PR TITLE
feat(server): add CLI tools for coding agent

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -16,6 +16,28 @@ FROM node:22-slim
 
 WORKDIR /app
 
+# Install CLI tools for coding agent
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    jq \
+    make \
+    ripgrep \
+    fd-find \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# fd is installed as fd-find, symlink to fd
+RUN ln -s $(which fdfind) /usr/local/bin/fd
+
 # Copy package files and install prod deps only
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev \


### PR DESCRIPTION
## Summary

Add essential CLI tools to the server container for coding agent operations.

## Tools added

| Tool | Package | Purpose |
|------|---------|---------|
| git | git | Repo operations (clone, commit, push) |
| gh | gh | GitHub CLI for PRs, issues, API |
| rg | ripgrep | Fast code search |
| fd | fd-find | Fast file finding |
| jq | jq | JSON processing |
| curl | curl | HTTP requests |
| make | make | Build automation |

## Notes

- `fd-find` installs as `fdfind`, added symlink to `fd`
- gh installed from GitHub official apt repo
- Used `--no-install-recommends` to keep image smaller