### PR TITLE
Add pi-native multi-platform SwiftUI app scaffold

### DIFF
--- a/apps/pi-native/README.md
+++ b/apps/pi-native/README.md
@@ -1,0 +1,23 @@
+# Pi Native
+
+Pi Native is a fresh, multi-platform SwiftUI client for Pi designed for iPhone and macOS.
+It is intentionally isolated from the existing desktop and mobile codebases so it can
+serve as a clean reference implementation.
+
+## Generate the Xcode project
+
+```bash
+xcodegen generate
+```
+
+## Open the project
+
+```bash
+open PiNative.xcodeproj
+```
+
+## Notes
+
+- Targets: **PiNative-iOS** and **PiNative-macOS**
+- Deployment targets are set to platform version 26.0 as requested.
+- UI uses a glass-like material style to align with modern Liquid Glass design.

--- a/apps/pi-native/Sources/Shared/Models/AppState.swift
+++ b/apps/pi-native/Sources/Shared/Models/AppState.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@MainActor
+final class AppState: ObservableObject {
+    @Published var viewModel: ChatViewModel
+
+    init() {
+        let service = LocalEchoChatService()
+        self.viewModel = ChatViewModel(service: service)
+    }
+
+    func resetSession() {
+        viewModel.resetSession()
+    }
+}

--- a/apps/pi-native/Sources/Shared/Models/ChatModels.swift
+++ b/apps/pi-native/Sources/Shared/Models/ChatModels.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct ChatSession: Identifiable, Hashable, Sendable {
+    let id: UUID
+    var title: String
+    var createdAt: Date
+
+    static func fresh() -> ChatSession {
+        ChatSession(id: UUID(), title: "New Session", createdAt: Date())
+    }
+}
+
+enum ChatRole: String, Codable, Sendable {
+    case user
+    case assistant
+    case system
+}
+
+struct ChatMessage: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let role: ChatRole
+    let content: String
+    let timestamp: Date
+
+    init(id: UUID = UUID(), role: ChatRole, content: String, timestamp: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+    }
+}

--- a/apps/pi-native/Sources/Shared/Models/ChatViewModel.swift
+++ b/apps/pi-native/Sources/Shared/Models/ChatViewModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published private(set) var session: ChatSession
+    @Published private(set) var messages: [ChatMessage]
+    @Published var inputText: String
+    @Published var isSending: Bool
+
+    private let service: ChatService
+
+    init(service: ChatService) {
+        self.service = service
+        self.session = ChatSession.fresh()
+        self.messages = [
+            ChatMessage(role: .system, content: "Welcome to Pi Native."),
+            ChatMessage(role: .assistant, content: "Ask me about your project, and I will help.")
+        ]
+        self.inputText = ""
+        self.isSending = false
+    }
+
+    func resetSession() {
+        session = ChatSession.fresh()
+        messages.removeAll()
+        messages.append(ChatMessage(role: .system, content: "New session started."))
+        inputText = ""
+    }
+
+    func sendMessage() async {
+        let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let userMessage = ChatMessage(role: .user, content: trimmed)
+        messages.append(userMessage)
+        inputText = ""
+        isSending = true
+
+        do {
+            let response = try await service.send(message: userMessage, in: session)
+            messages.append(response)
+        } catch {
+            messages.append(ChatMessage(role: .assistant, content: "Something went wrong. Please try again."))
+        }
+
+        isSending = false
+    }
+}

--- a/apps/pi-native/Sources/Shared/PiNativeApp.swift
+++ b/apps/pi-native/Sources/Shared/PiNativeApp.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct PiNativeApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(appState)
+        }
+        .commands {
+            CommandGroup(after: .appInfo) {
+                Button("New Session") {
+                    appState.resetSession()
+                }
+                .keyboardShortcut("n", modifiers: [.command, .shift])
+            }
+        }
+    }
+}

--- a/apps/pi-native/Sources/Shared/Services/ChatService.swift
+++ b/apps/pi-native/Sources/Shared/Services/ChatService.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol ChatService: Sendable {
+    func send(message: ChatMessage, in session: ChatSession) async throws -> ChatMessage
+}
+
+actor LocalEchoChatService: ChatService {
+    func send(message: ChatMessage, in session: ChatSession) async throws -> ChatMessage {
+        let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        let responseText = trimmed.isEmpty ? "Give me something to respond to." : "Echo: \(trimmed)"
+        return ChatMessage(role: .assistant, content: responseText)
+    }
+}

--- a/apps/pi-native/Sources/Shared/Styles/GlassPanel.swift
+++ b/apps/pi-native/Sources/Shared/Styles/GlassPanel.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct GlassPanel<Content: View>: View {
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(16)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(.white.opacity(0.18), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.12), radius: 18, x: 0, y: 8)
+    }
+}

--- a/apps/pi-native/Sources/Shared/Views/ChatView.swift
+++ b/apps/pi-native/Sources/Shared/Views/ChatView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct ChatView: View {
+    @ObservedObject var viewModel: ChatViewModel
+    @State private var scrollTarget: UUID?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            header
+            messageList
+            inputBar
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .frame(minWidth: 480, minHeight: 640)
+        .background(LinearGradient(colors: [.black, .gray.opacity(0.4)], startPoint: .top, endPoint: .bottom))
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Reset") {
+                    viewModel.resetSession()
+                }
+            }
+        }
+        .onChange(of: viewModel.messages) { _, newValue in
+            scrollTarget = newValue.last?.id
+        }
+    }
+
+    private var header: some View {
+        GlassPanel {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Pi Native")
+                        .font(.title2.bold())
+                    Text("Session: \(viewModel.session.title)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Label("Live", systemImage: viewModel.isSending ? "sparkles" : "bolt.horizontal")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var messageList: some View {
+        GlassPanel {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(viewModel.messages) { message in
+                            MessageRow(message: message)
+                                .id(message.id)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .onChange(of: scrollTarget) { _, target in
+                    guard let target else { return }
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        proxy.scrollTo(target, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var inputBar: some View {
+        GlassPanel {
+            HStack(spacing: 12) {
+                TextField("Ask Pi Native", text: $viewModel.inputText, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1...4)
+
+                Button {
+                    Task { await viewModel.sendMessage() }
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 26))
+                }
+                .buttonStyle(.plain)
+                .disabled(viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+}

--- a/apps/pi-native/Sources/Shared/Views/MessageRow.swift
+++ b/apps/pi-native/Sources/Shared/Views/MessageRow.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct MessageRow: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .assistant {
+                bubble
+                Spacer(minLength: 0)
+            } else {
+                Spacer(minLength: 0)
+                bubble
+            }
+        }
+    }
+
+    private var bubble: some View {
+        Text(message.content)
+            .font(.body)
+            .foregroundStyle(message.role == .user ? .black : .white)
+            .padding(12)
+            .background(bubbleBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private var bubbleBackground: some ShapeStyle {
+        switch message.role {
+        case .user:
+            return AnyShapeStyle(Color.white.opacity(0.85))
+        case .assistant:
+            return AnyShapeStyle(Color.blue.opacity(0.4))
+        case .system:
+            return AnyShapeStyle(Color.gray.opacity(0.35))
+        }
+    }
+}

--- a/apps/pi-native/Sources/Shared/Views/RootView.swift
+++ b/apps/pi-native/Sources/Shared/Views/RootView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        NavigationStack {
+            ChatView(viewModel: appState.viewModel)
+        }
+    }
+}

--- a/apps/pi-native/project.yml
+++ b/apps/pi-native/project.yml
@@ -1,0 +1,47 @@
+name: PiNative
+options:
+  bundleIdPrefix: me.aliou.pi-native
+  deploymentTarget:
+    iOS: '26.0'
+    macOS: '26.0'
+settings:
+  base:
+    SWIFT_VERSION: '6.0'
+    PRODUCT_NAME: PiNative
+    CURRENT_PROJECT_VERSION: 1
+    MARKETING_VERSION: 0.1.0
+    ENABLE_PREVIEWS: YES
+    DEVELOPMENT_ASSET_PATHS: "Sources/Shared/Preview Content"
+    SWIFT_STRICT_CONCURRENCY: complete
+    ENABLE_USER_SCRIPT_SANDBOXING: YES
+    CLANG_ENABLE_MODULES: YES
+    CLANG_ENABLE_OBJC_WEAK: YES
+    ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: YES
+    GCC_WARN_DOCUMENTATION_COMMENTS: YES
+    GCC_TREAT_WARNINGS_AS_ERRORS: NO
+
+packages: {}
+
+targets:
+  PiNative-iOS:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources/Shared
+    settings:
+      base:
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        TARGETED_DEVICE_FAMILY: 1
+        SUPPORTS_MACCATALYST: NO
+    scheme:
+      testTargets: []
+  PiNative-macOS:
+    type: application
+    platform: macOS
+    sources:
+      - path: Sources/Shared
+    settings:
+      base:
+        INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.productivity
+    scheme:
+      testTargets: []


### PR DESCRIPTION
### Motivation

- Provide a greenfield, multi-platform native client `pi-native` for iOS and macOS using a single shared Swift/SwiftUI codebase with thin platform adapters and modern conventions. 
- Start from scratch (do not reuse existing `desktop` or `mobile` components) and follow up-to-date best practices such as Swift Concurrency, Swift 6, and Liquid Glass-style UI materials. 

### Description

- Add an XcodeGen project manifest `project.yml` that defines `PiNative-iOS` and `PiNative-macOS` targets with deployment targets set to `26.0` and `SWIFT_VERSION: '6.0'`. 
- Introduce app entry `PiNativeApp.swift`, a shared `RootView` and `ChatView` UI with a reusable `GlassPanel` style to implement a modern glass-like shell. 
- Implement core chat domain models and logic via `ChatModels.swift`, `ChatViewModel.swift`, and `AppState.swift`, using `@MainActor`, `ObservableObject`, and Swift Concurrency patterns. 
- Provide a minimal `ChatService` API and a `LocalEchoChatService` actor stub to enable local preview and deterministic testing of UI flows without network or external dependencies. 
- Include a short `README.md` describing how to generate the Xcode project (`xcodegen generate`) and open it (`open PiNative.xcodeproj`).

### Testing

- No automated tests were executed for this scaffold-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d645adbc83238bb1fa64a4a34d13)