### PR TITLE
Add pi-native multi-target SwiftUI app (iOS + macOS) with Liquid Glass UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ pi-apps/
 ├── apps/
 │   ├── desktop/           # macOS app (local subprocess or relay)
 │   ├── mobile/            # iOS app (connects to relay)
+│   ├── pi-native/         # New SwiftUI iOS + macOS app (from-scratch)
 │   ├── relay-server/      # Relay API server (Node.js/Hono/SQLite)
 │   └── relay-dashboard/   # Relay admin UI (React Router v7/Vite)
 └── packages/
@@ -47,6 +48,10 @@ make xcode        # open in xcode
 
 Connects to the relay via REST + WebSocket. Cannot run pi locally (iOS limitation).
 
+### Pi Native (iOS + macOS)
+
+Greenfield SwiftUI app that targets iOS and macOS with shared UI and modern “Liquid Glass” styling.
+
 ### Relay Server
 
 API server that wraps Pi sessions, manages repos, and bridges WebSocket clients.
@@ -84,6 +89,8 @@ Bundle IDs are developer-specific. On first `make setup`, `Config/Local.xcconfig
 ```xcconfig
 PI_DESKTOP_BUNDLE_ID = dev.yourname.pi.desktop
 PI_MOBILE_BUNDLE_ID = dev.yourname.pi.mobile
+PI_NATIVE_IOS_BUNDLE_ID = dev.yourname.pi.native.ios
+PI_NATIVE_MAC_BUNDLE_ID = dev.yourname.pi.native.mac
 ```
 
 ## Commands

--- a/apps/pi-native/README.md
+++ b/apps/pi-native/README.md
@@ -1,0 +1,140 @@
+# Pi Native (iOS + macOS)
+
+## Purpose
+Pi Native is a from-scratch, multi‑target SwiftUI application meant to establish a modern baseline for a native AI chat + coding agent client on iOS and macOS. It emphasizes 2025‑era platform conventions ("Liquid Glass" translucency, layered depth, and motion) while remaining safe, accessible, and maintainable.
+
+This directory intentionally **does not reuse** code from `apps/desktop` or `apps/mobile`. It is a clean‑room implementation that only shares platform‑agnostic best practices and architectural patterns.
+
+---
+
+## Research: Best Practices for Multi‑Target iOS + macOS Apps (Feb 2, 2026)
+
+### 1) Product & UX Strategy
+- **Design for parity, not uniformity.** Maintain conceptual parity across platforms (features, data, capabilities), but allow UX differentiation for input modality, windowing, and multitasking. macOS benefits from denser layouts, richer sidebars, and multi‑window workflows; iOS favors concise views and progressive disclosure.
+- **Separate intent from presentation.** Model the domain (sessions, messages, tools, models) and business logic outside of UI layers so that each target can optimize presentation without branching logic in core flows.
+- **Leverage platform idioms.**
+  - iOS: haptics, pull‑to‑refresh, primary action at bottom, in‑context sheets.
+  - macOS: toolbar affordances, inline inspector panels, keyboard shortcuts, and drag‑and‑drop.
+
+### 2) Architecture
+- **Layered architecture with boundaries** between:
+  1. **Domain:** models, value types, policies (pure Swift, no UI).
+  2. **Application:** view models, orchestrators, state machines (async/await, `@MainActor`).
+  3. **Infrastructure:** persistence, networking, file access, analytics.
+  4. **UI:** SwiftUI views, AppKit/UIView bridging if needed.
+- **Prefer feature‑scoped modules** (e.g., `Chat`, `Sessions`, `Tools`, `Models`) and isolate dependencies in a `Core` module to avoid cyclic references.
+- **Use unidirectional data flow** to keep state predictable (e.g., simple reducer pattern, or a `ViewModel` with explicit actions and effects).
+- **Minimize shared mutable state.** Leverage `Sendable` models, `@MainActor` for UI state, and separate background tasks using `TaskGroup` where appropriate.
+
+### 3) SwiftUI & AppKit Interop
+- **SwiftUI-first, AppKit‑where‑needed.** SwiftUI is preferred for new UI; use `NSViewRepresentable`/`UIViewRepresentable` to bridge when high‑performance or native behaviors are missing.
+- **Avoid platform‑specific forks** unless required; prefer conditional modifiers and localized view composition to reduce duplication.
+- **Adopt modern navigation** with `NavigationStack` and value‑based routing where possible. Keep deep‑linking consistent across platforms.
+
+### 4) Liquid Glass (Translucency & Depth) Design
+- **Use layered materials** (`.ultraThinMaterial`, `.thinMaterial`) and subtle gradients to create depth without sacrificing contrast.
+- **Maintain legibility** by combining materials with proper foreground contrast, dynamic type support, and background dimming.
+- **Limit blur over text** to avoid readability issues. Prefer glass cards with padded content and defined edges.
+- **Keep motion calm.** Short, responsive animations reinforce focus without causing distraction or motion sensitivity.
+
+### 5) Accessibility & Localization
+- **Dynamic Type everywhere.** Use `.font(.body)` and semantic text styles, not fixed sizes. Avoid hardcoded line heights.
+- **Minimum tap targets** 44×44 points; provide keyboard equivalents on macOS.
+- **Localization‑ready strings.** Centralize copy and use `LocalizedStringKey` or string tables. Avoid string interpolation for user‑facing labels.
+- **VoiceOver & focus ordering.** Ensure logical reading order and meaningful labels for controls.
+
+### 6) Performance & Responsiveness
+- **Optimize rendering** with `LazyVStack`, stable IDs, and judicious use of `@StateObject`.
+- **Use async/await** for IO and long‑running tasks. Keep UI updates on the main actor.
+- **Streaming updates** should batch or debounce to avoid re‑render storms.
+- **Avoid holding large conversation history in memory** without paging or summarization for long sessions.
+
+### 7) Data & Persistence
+- **Use background persistence** (e.g., SQLite, Core Data, or custom store) for sessions and transcripts, and cache the last N messages for fast load.
+- **Keep message IDs stable** across devices to support merge, offline edits, or eventual sync.
+- **Encrypt sensitive data** (auth tokens, session secrets) using Keychain and file protection.
+
+### 8) Security & Privacy
+- **Principle of least privilege** for entitlements and capabilities.
+- **Explain data collection** in‑app and via privacy labels.
+- **Guard against prompt injection** when tool calls are allowed, and isolate untrusted content.
+- **Validate file access** for code operations and use scoped bookmarks for macOS sandboxing.
+
+### 9) Build & Release Hygiene
+- **Automate** with CI for lint, unit tests, and snapshot tests.
+- **Use XcodeGen or SwiftPM** for deterministic project generation.
+- **Keep config centralized** in `.xcconfig` files.
+
+---
+
+## Research: Best Practices for AI Chat + Coding Agent Apps (Feb 2, 2026)
+
+### 1) Interaction Model & Trust
+- **Explicit agent state**: clearly show if the agent is thinking, streaming, or executing tools.
+- **Explainability**: show tool inputs/outputs and allow users to inspect or redact actions.
+- **User control**: provide pause/abort, retry, and manual edit points.
+- **Provenance**: highlight which data sources were used and when.
+
+### 2) Context Management
+- **Token budgeting**: keep a rolling summary and clip or compress older content.
+- **Chunk code**: split large code files and send diff‑based updates rather than entire files.
+- **Personalization with guardrails**: allow custom instructions but sandbox tool usage.
+
+### 3) Tooling & Execution Safety
+- **Tool whitelisting** and sandboxing for file ops, network, and system access.
+- **Audit logs** for tool calls; ensure the user can review or export them.
+- **Idempotent operations**: enforce safe retries for patching and file changes.
+- **Structured tool outputs** to prevent prompt injection via untrusted tool results.
+
+### 4) Code‑Aware UX
+- **Diff‑first UI**: show edits as diffs, allow selective apply/reject.
+- **Typed repositories**: show repo state, branch, and dirty files at a glance.
+- **Inline diagnostics**: present errors from builds/lints with quick fixes.
+
+### 5) Performance & Streaming
+- **Streaming UI** with incremental rendering; avoid reflow by appending updates rather than re‑creating views.
+- **Backpressure**: throttle tokens and UI updates for stable scroll/selection behavior.
+
+### 6) Offline & Reliability
+- **Graceful degradation**: allow browsing previous sessions when offline.
+- **Retry strategy** with exponential backoff for reconnections.
+- **Deterministic resumes**: persist the last known message sequence and replay changes after reconnect.
+
+### 7) Responsible AI
+- **Safety policies** should be visible and actionable (not hidden in terms).
+- **Clear boundaries** for tool actions, especially for code execution, file deletion, or network access.
+- **Privacy‑first** defaults for logging and analytics.
+
+---
+
+## Pi Native Implementation Notes
+
+### Current Scope
+- **Shared SwiftUI UI** in `Sources/Shared/`.
+- **Per‑platform entry points** in `Sources/iOS/` and `Sources/macOS/`.
+- **Glass‑inspired UI** with layered materials and depth.
+
+### Project Structure
+```
+apps/pi-native/
+├─ project.yml
+├─ README.md
+├─ Resources/
+│  ├─ Assets.xcassets/
+│  ├─ iOS/Info.plist
+│  └─ macOS/Info.plist
+└─ Sources/
+   ├─ Shared/
+   │  ├─ Models/
+   │  ├─ ViewModels/
+   │  └─ Views/
+   ├─ iOS/
+   └─ macOS/
+```
+
+### Next Steps (Recommended)
+- Add a relay client (REST + WebSocket) with protocol‑layer isolation.
+- Add structured tool call UI and streaming transcript view.
+- Introduce persistence for sessions and offline history.
+- Add tests for view models and deterministic reducer logic.
+

--- a/apps/pi-native/Resources/Assets.xcassets/Contents.json
+++ b/apps/pi-native/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/pi-native/Resources/iOS/Info.plist
+++ b/apps/pi-native/Resources/iOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Pi Native</string>
+  <key>CFBundleName</key>
+  <string>Pi Native</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+</dict>
+</plist>

--- a/apps/pi-native/Resources/macOS/Info.plist
+++ b/apps/pi-native/Resources/macOS/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Pi Native</string>
+  <key>CFBundleName</key>
+  <string>Pi Native</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright © 2026</string>
+</dict>
+</plist>

--- a/apps/pi-native/Sources/Shared/Models/ChatMessage.swift
+++ b/apps/pi-native/Sources/Shared/Models/ChatMessage.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct ChatMessage: Identifiable, Sendable {
+    enum Role: String, Sendable {
+        case user
+        case assistant
+        case system
+    }
+
+    let id: UUID
+    let role: Role
+    let content: String
+    let createdAt: Date
+
+    init(id: UUID = UUID(), role: Role, content: String, createdAt: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+    }
+}

--- a/apps/pi-native/Sources/Shared/ViewModels/ChatViewModel.swift
+++ b/apps/pi-native/Sources/Shared/ViewModels/ChatViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    @Published var draft: String = ""
+    @Published var statusText: String = "Ready"
+
+    init() {
+        let welcome = ChatMessage(
+            role: .system,
+            content: "Welcome to Pi Native. This preview focuses on agent UX, streaming-ready layout, and Liquid Glass styling."
+        )
+        messages = [welcome]
+    }
+
+    func send() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let userMessage = ChatMessage(role: .user, content: trimmed)
+        messages.append(userMessage)
+        draft = ""
+        statusText = "Thinking…"
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(0.7))
+            let response = ChatMessage(
+                role: .assistant,
+                content: "This is a placeholder response. Wire me to the relay or a local model."
+            )
+            messages.append(response)
+            statusText = "Ready"
+        }
+    }
+}

--- a/apps/pi-native/Sources/Shared/Views/GlassCard.swift
+++ b/apps/pi-native/Sources/Shared/Views/GlassCard.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct GlassCard<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(.ultraThinMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(.white.opacity(0.25), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.12), radius: 12, x: 0, y: 6)
+    }
+}

--- a/apps/pi-native/Sources/Shared/Views/MessageRow.swift
+++ b/apps/pi-native/Sources/Shared/Views/MessageRow.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct MessageRow: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Circle()
+                .fill(badgeColor)
+                .frame(width: 28, height: 28)
+                .overlay(
+                    Text(badgeText)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                )
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(roleLabel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(message.content)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.thinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(.white.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    private var badgeText: String {
+        switch message.role {
+        case .assistant:
+            return "AI"
+        case .user:
+            return "ME"
+        case .system:
+            return "SYS"
+        }
+    }
+
+    private var roleLabel: String {
+        switch message.role {
+        case .assistant:
+            return "Assistant"
+        case .user:
+            return "You"
+        case .system:
+            return "System"
+        }
+    }
+
+    private var badgeColor: Color {
+        switch message.role {
+        case .assistant:
+            return .blue
+        case .user:
+            return .green
+        case .system:
+            return .gray
+        }
+    }
+}

--- a/apps/pi-native/Sources/Shared/Views/RootView.swift
+++ b/apps/pi-native/Sources/Shared/Views/RootView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct RootView: View {
+    @StateObject private var viewModel = ChatViewModel()
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                LinearGradient(
+                    colors: [Color.blue.opacity(0.25), Color.purple.opacity(0.25), Color.indigo.opacity(0.35)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+
+                VStack(spacing: 16) {
+                    header
+
+                    GlassCard {
+                        ScrollView {
+                            LazyVStack(alignment: .leading, spacing: 12) {
+                                ForEach(viewModel.messages) { message in
+                                    MessageRow(message: message)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+
+                    composer
+                }
+                .padding()
+            }
+            .navigationTitle("Pi Native")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+        }
+    }
+
+    private var header: some View {
+        GlassCard {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Liquid Glass Workspace")
+                        .font(.title2.weight(.semibold))
+                    Text("Status: \(viewModel.statusText)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button {
+                    viewModel.messages = viewModel.messages.prefix(1).map { $0 }
+                    viewModel.statusText = "Ready"
+                } label: {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private var composer: some View {
+        GlassCard {
+            HStack(spacing: 12) {
+                TextField("Ask Pi Native to draft, plan, or code…", text: $viewModel.draft, axis: .vertical)
+                    .lineLimit(1...4)
+                    .textFieldStyle(.plain)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(.thinMaterial)
+                    )
+
+                Button {
+                    viewModel.send()
+                } label: {
+                    Image(systemName: "paperplane.fill")
+                        .font(.headline)
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+}

--- a/apps/pi-native/Sources/iOS/PiNativeApp.swift
+++ b/apps/pi-native/Sources/iOS/PiNativeApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct PiNativeiOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+        }
+    }
+}

--- a/apps/pi-native/Sources/macOS/PiNativeApp.swift
+++ b/apps/pi-native/Sources/macOS/PiNativeApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct PiNativeMacApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+        }
+        .defaultSize(width: 1100, height: 760)
+    }
+}

--- a/apps/pi-native/project.yml
+++ b/apps/pi-native/project.yml
@@ -1,0 +1,71 @@
+name: pi-native
+options:
+  bundleIdPrefix: ""
+  deploymentTarget:
+    iOS: "26.0"
+    macOS: "26.0"
+  xcodeVersion: "26.0"
+  createIntermediateGroups: true
+  generateEmptyDirectories: true
+
+configFiles:
+  Debug: ../../Config/Debug.xcconfig
+  Release: ../../Config/Release.xcconfig
+
+settings:
+  base:
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+    CODE_SIGN_STYLE: Automatic
+    SWIFT_VERSION: "6.0"
+
+targets:
+  PiNativeiOS:
+    type: application
+    platform: iOS
+    supportedDestinations: [iOS]
+    sources:
+      - path: Sources/Shared
+        type: syncedFolder
+      - path: Sources/iOS
+        type: syncedFolder
+      - path: Resources/Assets.xcassets
+    settings:
+      base:
+        INFOPLIST_FILE: Resources/iOS/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: $(PI_NATIVE_IOS_BUNDLE_ID)
+        PRODUCT_NAME: Pi Native
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        TARGETED_DEVICE_FAMILY: "1"
+
+  PiNativemacOS:
+    type: application
+    platform: macOS
+    sources:
+      - path: Sources/Shared
+        type: syncedFolder
+      - path: Sources/macOS
+        type: syncedFolder
+      - path: Resources/Assets.xcassets
+    settings:
+      base:
+        INFOPLIST_FILE: Resources/macOS/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: $(PI_NATIVE_MAC_BUNDLE_ID)
+        PRODUCT_NAME: Pi Native
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        COMBINE_HIDPI_IMAGES: YES
+        ENABLE_APP_SANDBOX: YES
+
+schemes:
+  Pi Native iOS:
+    build:
+      targets:
+        PiNativeiOS: all
+    run:
+      config: Debug
+  Pi Native macOS:
+    build:
+      targets:
+        PiNativemacOS: all
+    run:
+      config: Debug


### PR DESCRIPTION
### Motivation
- Provide a greenfield native client for Pi that targets both iOS and macOS with a shared SwiftUI codebase and modern “Liquid Glass” styling as a baseline for AI chat / coding agent UX. 
- Keep a clean‑room implementation that does not reuse `apps/desktop` or `apps/mobile` components so the app can evolve independently with clear architecture boundaries. 
- Prepare a scaffold for future work (relay client, tool UI, persistence, streaming) and document platform + agent best practices discovered during research.

### Description
- Add a new XcodeGen project at `apps/pi-native/project.yml` with iOS and macOS targets (deployment target `26.0`, Xcode `26.0`) and configurable bundle IDs via `$(PI_NATIVE_IOS_BUNDLE_ID)` and `$(PI_NATIVE_MAC_BUNDLE_ID)`.
- Add shared app code under `apps/pi-native/Sources/Shared/` including `ChatMessage.swift`, `ChatViewModel.swift`, and SwiftUI views `GlassCard.swift`, `MessageRow.swift`, and `RootView.swift` to demonstrate a streaming-ready, Liquid Glass UI pattern.
- Add per-platform entry points `Sources/iOS/PiNativeApp.swift` and `Sources/macOS/PiNativeApp.swift`, resource plist files in `Resources/`, and an empty `Assets.xcassets` container.
- Add `apps/pi-native/README.md` containing in-depth research and recommended next steps for multi-target app architecture and AI agent best practices, and update the repository `README.md` to list the new app and new `PI_NATIVE_*` config keys.

### Testing
- No automated tests were executed as part of this change (no test targets were added in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d645adbc83238bb1fa64a4a34d13)