### PR TITLE
feat: add local sandbox provider

### DIFF
--- a/clients/dashboard/app/components/sandbox-terminal.tsx
+++ b/clients/dashboard/app/components/sandbox-terminal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { RELAY_URL, type SandboxStatusResponse } from "../lib/api";
+import { getRelayWsUrl, type SandboxStatusResponse } from "../lib/api";
 import { cn } from "../lib/utils";
 
 interface SandboxTerminalProps {
@@ -63,7 +63,15 @@ function TerminalInstance({ sessionId }: { sessionId: string }) {
 
       const cols = terminal.cols ?? 80;
       const rows = terminal.rows ?? 24;
-      const wsUrl = `${RELAY_URL.replace("http", "ws")}/ws/sessions/${sessionId}/terminal?cols=${cols}&rows=${rows}`;
+      const relayWsUrl = getRelayWsUrl();
+      if (!relayWsUrl) {
+        if (!cancelled) {
+          setError("Relay WebSocket URL is not configured");
+          setStatus("error");
+        }
+        return;
+      }
+      const wsUrl = `${relayWsUrl}/ws/sessions/${sessionId}/terminal?cols=${cols}&rows=${rows}`;
 
       ws = new WebSocket(wsUrl);
 
@@ -164,7 +172,7 @@ function TerminalInstance({ sessionId }: { sessionId: string }) {
             : status === "connecting"
               ? "Connecting..."
               : status === "error"
-                ? error ?? "Error"
+                ? (error ?? "Error")
                 : "Exited"}
         </span>
       </div>

--- a/clients/dashboard/app/lib/api.ts
+++ b/clients/dashboard/app/lib/api.ts
@@ -9,6 +9,19 @@ export type APIResponse<T> =
 export const RELAY_URL = import.meta.env.VITE_RELAY_URL ?? "";
 const BASE_URL = `${RELAY_URL}/api`;
 
+export function getRelayWsUrl(): string {
+  const relayUrl =
+    RELAY_URL || (typeof window !== "undefined" ? window.location.origin : "");
+
+  if (!relayUrl) {
+    return "";
+  }
+
+  const url = new URL(relayUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString().replace(/\/$/, "");
+}
+
 async function request<T>(
   path: string,
   options?: RequestInit,
@@ -68,22 +81,54 @@ export const api = {
 
 const CLIENT_ID_KEY = "pi-dashboard-client-id";
 
+export function createId(): string {
+  const cryptoApi = globalThis.crypto;
+
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+
+  if (cryptoApi?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    cryptoApi.getRandomValues(bytes);
+    bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+    bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+    return [
+      hex.slice(0, 4).join(""),
+      hex.slice(4, 6).join(""),
+      hex.slice(6, 8).join(""),
+      hex.slice(8, 10).join(""),
+      hex.slice(10, 16).join(""),
+    ].join("-");
+  }
+
+  return `id-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
 /**
  * Get or generate a persistent client ID for this browser.
  * Stored in localStorage and reused across sessions.
  */
 export function getClientId(): string {
+  const fallbackId = createId();
+
   if (typeof window === "undefined") {
-    // SSR fallback - generate temporary ID
-    return crypto.randomUUID();
+    return fallbackId;
   }
 
-  let clientId = localStorage.getItem(CLIENT_ID_KEY);
-  if (!clientId) {
-    clientId = crypto.randomUUID();
-    localStorage.setItem(CLIENT_ID_KEY, clientId);
+  try {
+    const existing = window.localStorage.getItem(CLIENT_ID_KEY);
+    if (existing) {
+      return existing;
+    }
+
+    window.localStorage.setItem(CLIENT_ID_KEY, fallbackId);
+  } catch {
+    return fallbackId;
   }
-  return clientId;
+
+  return fallbackId;
 }
 
 /**
@@ -259,7 +304,7 @@ export interface SessionHistoryEntry {
 export interface Environment {
   id: string;
   name: string;
-  sandboxType: "docker" | "cloudflare" | "gondolin";
+  sandboxType: "docker" | "cloudflare" | "gondolin" | "local";
   config: EnvironmentConfig;
   isDefault: boolean;
   createdAt: string;
@@ -271,6 +316,7 @@ export interface EnvironmentConfig {
   workerUrl?: string;
   secretId?: string;
   imagePath?: string;
+  piBinaryPath?: string;
   idleTimeoutSeconds?: number;
   envVars?: Array<{ key: string; value: string }>;
   resources?: {
@@ -288,7 +334,7 @@ export interface AvailableImage {
 
 export interface CreateEnvironmentRequest {
   name: string;
-  sandboxType: "docker" | "cloudflare" | "gondolin";
+  sandboxType: "docker" | "cloudflare" | "gondolin" | "local";
   config: EnvironmentConfig;
   isDefault?: boolean;
 }
@@ -302,6 +348,7 @@ export interface UpdateEnvironmentRequest {
 export interface SandboxProviderStatus {
   docker: { available: boolean };
   gondolin: { available: boolean };
+  local: { available: boolean };
 }
 
 export interface ProbeResult {

--- a/clients/dashboard/app/routes/dashboard.tsx
+++ b/clients/dashboard/app/routes/dashboard.tsx
@@ -150,6 +150,7 @@ export default function DashboardPage() {
   const [defaults, setDefaults] = useState<SessionDefaults>({});
 
   const [selectedRepoId, setSelectedRepoId] = useState<string>("");
+  const [localPath, setLocalPath] = useState<string>("");
   const [selectedEnvironmentId, setSelectedEnvironmentId] =
     useState<string>("");
   const [message, setMessage] = useState("");
@@ -209,9 +210,18 @@ export default function DashboardPage() {
     [environments],
   );
 
+  const selectedEnvironment = useMemo(
+    () => environments.find((e) => e.id === selectedEnvironmentId),
+    [environments, selectedEnvironmentId],
+  );
+
+  const isLocalEnvironment = selectedEnvironment?.sandboxType === "local";
+
   const canSubmit =
     message.trim().length > 0 &&
-    (mode === "chat" || (!!selectedRepoId && !!selectedEnvironmentId));
+    !!selectedEnvironmentId &&
+    (mode === "chat" ||
+      (isLocalEnvironment ? !!localPath.trim() : !!selectedRepoId));
 
   const handleSubmit = async () => {
     if (!canSubmit || isSubmitting) return;
@@ -225,8 +235,13 @@ export default function DashboardPage() {
 
     const res = await api.post<{ id: string }>("/sessions", {
       mode,
-      repoId: mode === "code" ? selectedRepoId : undefined,
-      environmentId: mode === "code" ? selectedEnvironmentId : undefined,
+      repoId:
+        mode === "code"
+          ? isLocalEnvironment
+            ? localPath.trim()
+            : selectedRepoId
+          : undefined,
+      environmentId: selectedEnvironmentId,
       modelProvider: modeDefaults?.modelProvider,
       modelId: modeDefaults?.modelId,
       firstPrompt,
@@ -293,29 +308,45 @@ export default function DashboardPage() {
                 : "mb-0 max-h-0 -translate-y-1 opacity-0 pointer-events-none",
             )}
           >
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              <div className="space-y-2">
-                <span className="text-xs text-muted">Repository</span>
-                <SearchableSelect
-                  items={repoItems}
-                  value={selectedRepoId}
-                  onValueChange={setSelectedRepoId}
-                  placeholder="Select repository"
-                  icon={<GithubLogoIcon className="size-4" />}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <span className="text-xs text-muted">Environment</span>
-                <SearchableSelect
-                  items={environmentItems}
-                  value={selectedEnvironmentId}
-                  onValueChange={setSelectedEnvironmentId}
-                  placeholder="Select environment"
-                  icon={<CloudIcon className="size-4" />}
-                />
-              </div>
+            <div className="grid grid-cols-1 gap-3">
+              {isLocalEnvironment ? (
+                <div className="space-y-2">
+                  <label htmlFor="local-path" className="text-xs text-muted">
+                    Local Path
+                  </label>
+                  <input
+                    id="local-path"
+                    type="text"
+                    value={localPath}
+                    onChange={(e) => setLocalPath(e.target.value)}
+                    placeholder="/path/to/your/project"
+                    className="w-full rounded-lg border border-border bg-surface/50 px-3 py-2.5 text-sm text-fg placeholder:text-muted/50 focus:border-accent/50 focus:outline-none"
+                  />
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <span className="text-xs text-muted">Repository</span>
+                  <SearchableSelect
+                    items={repoItems}
+                    value={selectedRepoId}
+                    onValueChange={setSelectedRepoId}
+                    placeholder="Select repository"
+                    icon={<GithubLogoIcon className="size-4" />}
+                  />
+                </div>
+              )}
             </div>
+          </div>
+
+          <div className="mb-4 space-y-2">
+            <span className="text-xs text-muted">Environment</span>
+            <SearchableSelect
+              items={environmentItems}
+              value={selectedEnvironmentId}
+              onValueChange={setSelectedEnvironmentId}
+              placeholder="Select environment"
+              icon={<CloudIcon className="size-4" />}
+            />
           </div>
 
           <div
@@ -361,13 +392,16 @@ export default function DashboardPage() {
 
           {error && <p className="mt-3 text-sm text-status-err">{error}</p>}
 
-          {!isLoading && mode === "code" && repos.length === 0 && (
-            <p className="mt-3 text-xs text-muted">
-              No repositories found. Configure GitHub token in settings.
-            </p>
-          )}
+          {!isLoading &&
+            mode === "code" &&
+            !isLocalEnvironment &&
+            repos.length === 0 && (
+              <p className="mt-3 text-xs text-muted">
+                No repositories found. Configure GitHub token in settings.
+              </p>
+            )}
 
-          {!isLoading && mode === "code" && environments.length === 0 && (
+          {!isLoading && environments.length === 0 && (
             <p className="mt-1 text-xs text-muted">
               No environments found. Create one in settings.
             </p>

--- a/clients/dashboard/app/routes/environments.tsx
+++ b/clients/dashboard/app/routes/environments.tsx
@@ -56,7 +56,7 @@ function EnvironmentDialog({
   const isEdit = !!environment;
   const [name, setName] = useState(environment?.name ?? "");
   const [sandboxType, setSandboxType] = useState<
-    "docker" | "cloudflare" | "gondolin"
+    "docker" | "cloudflare" | "gondolin" | "local"
   >(environment?.sandboxType ?? "docker");
   const [image, setImage] = useState(
     environment?.config.image ?? images[0]?.image ?? "",
@@ -70,6 +70,9 @@ function EnvironmentDialog({
   );
   const [envVars, setEnvVars] = useState<Array<{ key: string; value: string }>>(
     environment?.config.envVars ?? [],
+  );
+  const [piBinaryPath, setPiBinaryPath] = useState(
+    environment?.config.piBinaryPath ?? "",
   );
   const [isDefault, setIsDefault] = useState(environment?.isDefault ?? false);
   const [idleTimeout, setIdleTimeout] = useState(
@@ -150,7 +153,8 @@ function EnvironmentDialog({
     const isConfigComplete =
       (sandboxType === "docker" && !!image) ||
       (sandboxType === "cloudflare" && !!workerUrl.trim() && !!secretId) ||
-      sandboxType === "gondolin";
+      sandboxType === "gondolin" ||
+      sandboxType === "local";
 
     if (!isConfigComplete) return;
 
@@ -164,7 +168,13 @@ function EnvironmentDialog({
           ? { image }
           : sandboxType === "cloudflare"
             ? { workerUrl, secretId }
-            : { ...(imagePath.trim() ? { imagePath: imagePath.trim() } : {}) };
+            : sandboxType === "gondolin"
+              ? { ...(imagePath.trim() ? { imagePath: imagePath.trim() } : {}) }
+              : {
+                  ...(piBinaryPath.trim()
+                    ? { piBinaryPath: piBinaryPath.trim() }
+                    : {}),
+                };
 
       const res = await api.post<ProbeResult>("/environments/probe", {
         sandboxType,
@@ -188,7 +198,7 @@ function EnvironmentDialog({
       cancelled = true;
       clearTimeout(timeout);
     };
-  }, [sandboxType, image, workerUrl, secretId, imagePath]);
+  }, [sandboxType, image, workerUrl, secretId, imagePath, piBinaryPath]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -210,11 +220,18 @@ function EnvironmentDialog({
           ? { image, idleTimeoutSeconds: idleTimeout, ...sharedConfig }
           : sandboxType === "cloudflare"
             ? { workerUrl, secretId, ...sharedConfig }
-            : {
-                idleTimeoutSeconds: idleTimeout,
-                ...(imagePath.trim() ? { imagePath: imagePath.trim() } : {}),
-                ...sharedConfig,
-              };
+            : sandboxType === "gondolin"
+              ? {
+                  idleTimeoutSeconds: idleTimeout,
+                  ...(imagePath.trim() ? { imagePath: imagePath.trim() } : {}),
+                  ...sharedConfig,
+                }
+              : {
+                  ...(piBinaryPath.trim()
+                    ? { piBinaryPath: piBinaryPath.trim() }
+                    : {}),
+                  ...sharedConfig,
+                };
 
       if (isEdit) {
         const update: UpdateEnvironmentRequest = {
@@ -331,7 +348,8 @@ function EnvironmentDialog({
                           e.target.value as
                             | "docker"
                             | "cloudflare"
-                            | "gondolin",
+                            | "gondolin"
+                            | "local",
                         )
                       }
                       className="size-4 border-border accent-accent"
@@ -348,7 +366,8 @@ function EnvironmentDialog({
                           e.target.value as
                             | "docker"
                             | "cloudflare"
-                            | "gondolin",
+                            | "gondolin"
+                            | "local",
                         )
                       }
                       className="size-4 border-border accent-accent"
@@ -365,12 +384,31 @@ function EnvironmentDialog({
                           e.target.value as
                             | "docker"
                             | "cloudflare"
-                            | "gondolin",
+                            | "gondolin"
+                            | "local",
                         )
                       }
                       className="size-4 border-border accent-accent"
                     />
                     <span className="text-sm text-fg">Gondolin</span>
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      value="local"
+                      checked={sandboxType === "local"}
+                      onChange={(e) =>
+                        setSandboxType(
+                          e.target.value as
+                            | "docker"
+                            | "cloudflare"
+                            | "gondolin"
+                            | "local",
+                        )
+                      }
+                      className="size-4 border-border accent-accent"
+                    />
+                    <span className="text-sm text-fg">Local</span>
                   </label>
                 </div>
               </div>
@@ -680,6 +718,49 @@ function EnvironmentDialog({
                 </div>
               )}
 
+              {/* Local options */}
+              {sandboxType === "local" && (
+                <div className="space-y-4">
+                  <div>
+                    <label
+                      htmlFor="env-local-pi-binary-path"
+                      className="mb-1.5 block text-xs font-medium text-muted"
+                    >
+                      Pi Binary Path (optional)
+                    </label>
+                    <input
+                      id="env-local-pi-binary-path"
+                      type="text"
+                      value={piBinaryPath}
+                      onChange={(e) => setPiBinaryPath(e.target.value)}
+                      placeholder="/usr/local/bin/pi or /path/to/custom/pi"
+                      className="w-full rounded-lg border border-border bg-surface/30 px-3 py-2 text-sm text-fg placeholder:text-muted/50 focus:border-accent focus:outline-none"
+                    />
+                    <p className="mt-1 text-xs text-muted">
+                      Leave empty to use the pi binary in PATH.
+                    </p>
+                  </div>
+
+                  {probeStatus === "probing" && (
+                    <p className="text-xs text-muted">
+                      Checking availability...
+                    </p>
+                  )}
+                  {probeStatus === "available" && (
+                    <p className="flex items-center gap-1 text-xs text-green-500">
+                      <CheckCircleIcon className="size-3" weight="fill" />
+                      Available
+                    </p>
+                  )}
+                  {probeStatus === "unavailable" && (
+                    <p className="flex items-center gap-1 text-xs text-red-500">
+                      <WarningCircleIcon className="size-3" weight="fill" />
+                      {probeError ?? "Not available"}
+                    </p>
+                  )}
+                </div>
+              )}
+
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-medium text-muted">
@@ -854,6 +935,7 @@ function EnvironmentRow({
 
   const isCloudflare = environment.sandboxType === "cloudflare";
   const isGondolin = environment.sandboxType === "gondolin";
+  const isLocal = environment.sandboxType === "local";
 
   const formatIdleTimeout = (seconds: number) => {
     const minutes = seconds / 60;
@@ -872,7 +954,9 @@ function EnvironmentRow({
             ? "bg-orange-500/10 text-orange-500"
             : isGondolin
               ? "bg-violet-500/10 text-violet-500"
-              : "bg-accent/10 text-accent"
+              : isLocal
+                ? "bg-blue-500/10 text-blue-500"
+                : "bg-accent/10 text-accent"
         }`}
       >
         {isCloudflare ? (
@@ -903,11 +987,13 @@ function EnvironmentRow({
                     ? ` • ${formatIdleTimeout(environment.config.idleTimeoutSeconds)}`
                     : ""
                 }`
-              : `${imageMeta?.name ?? environment.config.image}${
-                  environment.config.idleTimeoutSeconds
-                    ? ` • ${formatIdleTimeout(environment.config.idleTimeoutSeconds)}`
-                    : ""
-                }`}
+              : isLocal
+                ? `Local${environment.config.piBinaryPath ? ` (${environment.config.piBinaryPath})` : ""}`
+                : `${imageMeta?.name ?? environment.config.image}${
+                    environment.config.idleTimeoutSeconds
+                      ? ` • ${formatIdleTimeout(environment.config.idleTimeoutSeconds)}`
+                      : ""
+                  }`}
         </p>
       </div>
 

--- a/server/relay/package.json
+++ b/server/relay/package.json
@@ -29,6 +29,7 @@
     "drizzle-orm": "^0.39.3",
     "hono": "^4.7.4",
     "hono-pino": "^0.10.3",
+    "node-pty": "^1.1.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3"
   },
@@ -47,7 +48,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3",
-      "esbuild"
+      "esbuild",
+      "node-pty"
     ]
   }
 }

--- a/server/relay/pnpm-lock.yaml
+++ b/server/relay/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       hono-pino:
         specifier: ^0.10.3
         version: 0.10.3(hono@4.11.9)(pino@10.3.1)
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -1370,9 +1373,15 @@ packages:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-forge@1.3.3:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   nofilter@3.1.0:
     resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
@@ -2654,7 +2663,13 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-addon-api@7.1.1: {}
+
   node-forge@1.3.3: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   nofilter@3.1.0: {}
 

--- a/server/relay/src/db/schema.ts
+++ b/server/relay/src/db/schema.ts
@@ -11,7 +11,7 @@ export const environments = sqliteTable("environments", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   sandboxType: text("sandbox_type", {
-    enum: ["docker", "cloudflare", "gondolin"],
+    enum: ["docker", "cloudflare", "gondolin", "local"],
   }).notNull(),
   config: text("config").notNull(), // JSON string: { image, resources? }
   isDefault: integer("is_default", { mode: "boolean" })
@@ -31,7 +31,7 @@ export const sessions = sqliteTable("sessions", {
     .notNull()
     .default("creating"),
   sandboxProvider: text("sandbox_provider", {
-    enum: ["mock", "docker", "cloudflare", "gondolin"],
+    enum: ["mock", "docker", "cloudflare", "gondolin", "local"],
   }),
   sandboxProviderId: text("sandbox_provider_id"),
   environmentId: text("environment_id").references(() => environments.id),

--- a/server/relay/src/index.ts
+++ b/server/relay/src/index.ts
@@ -125,6 +125,9 @@ async function main() {
       gondolin: {
         sessionDataDir,
       },
+      local: {
+        sessionDataDir,
+      },
       logStore: sandboxLogStore,
     },
     secretsService,

--- a/server/relay/src/routes/environments.ts
+++ b/server/relay/src/routes/environments.ts
@@ -47,6 +47,7 @@ function toSandboxConfig(
     workerUrl: config.workerUrl,
     apiToken,
     imagePath: config.imagePath,
+    piBinaryPath: config.piBinaryPath,
     env: config.envVars
       ? Object.fromEntries(
           config.envVars.map((entry) => [entry.key, entry.value]),
@@ -129,6 +130,13 @@ function validateConfig(
       typeof config.imagePath !== "string"
     ) {
       return "config.imagePath must be a string when provided";
+    }
+  } else if (sandboxType === "local") {
+    if (
+      config.piBinaryPath !== undefined &&
+      typeof config.piBinaryPath !== "string"
+    ) {
+      return "config.piBinaryPath must be a string when provided";
     }
   }
 
@@ -311,7 +319,12 @@ export function environmentsRoutes(): Hono<AppEnv> {
       return c.json({ data: null, error: "Invalid JSON body" }, 400);
     }
 
-    const validTypes: SandboxType[] = ["docker", "cloudflare", "gondolin"];
+    const validTypes: SandboxType[] = [
+      "docker",
+      "cloudflare",
+      "gondolin",
+      "local",
+    ];
     if (!body.sandboxType || !validTypes.includes(body.sandboxType)) {
       return c.json(
         {
@@ -388,6 +401,7 @@ export function environmentsRoutes(): Hono<AppEnv> {
       "docker",
       "cloudflare",
       "gondolin",
+      "local",
     ];
     if (!body.sandboxType || !validSandboxTypes.includes(body.sandboxType)) {
       return c.json(

--- a/server/relay/src/routes/models.ts
+++ b/server/relay/src/routes/models.ts
@@ -84,13 +84,19 @@ export function modelsRoutes(): Hono<AppEnv> {
     const environmentService = c.get("environmentService");
     const sessionDataDir = c.get("sessionDataDir");
 
+    const allEnvs = environmentService.list();
     const packages = extensionConfigService.getResolvedPackages(
       "_introspect",
       "code",
     );
     const secretsList = await secretsService.list();
     const secrets = await secretsService.getAllAsEnv();
-    const fingerprint = computeFingerprint(packages, secrets, secretsList);
+    const fingerprint = computeFingerprint(
+      packages,
+      secrets,
+      secretsList,
+      allEnvs,
+    );
 
     logger.debug(
       {
@@ -124,7 +130,7 @@ export function modelsRoutes(): Hono<AppEnv> {
 
     const introspectionSetting = getIntrospectionSetting(db);
     const candidates = buildIntrospectionCandidates(
-      environmentService.list(),
+      allEnvs,
       introspectionSetting.environmentId,
       logger,
     );
@@ -354,6 +360,13 @@ function computeFingerprint(
   packages: string[],
   secrets: Record<string, string>,
   secretsList?: SecretInfo[],
+  environments?: Array<{
+    id: string;
+    sandboxType: string;
+    isDefault: boolean;
+    config: string;
+    updatedAt: string;
+  }>,
 ): string {
   const hash = createHash("sha256");
 
@@ -376,6 +389,15 @@ function computeFingerprint(
       if (s.domains && s.domains.length > 0) {
         hash.update(`domains:${s.envVar}:${s.domains.sort().join(",")}\n`);
       }
+    }
+  }
+
+  if (environments) {
+    const sorted = [...environments].sort((a, b) => a.id.localeCompare(b.id));
+    for (const env of sorted) {
+      hash.update(
+        `env:${env.id}:${env.sandboxType}:${env.isDefault ? "default" : "non-default"}:${env.config}:${env.updatedAt}\n`,
+      );
     }
   }
 

--- a/server/relay/src/routes/sessions.test.ts
+++ b/server/relay/src/routes/sessions.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { type AppServices, createApp } from "../app";
@@ -7,7 +8,7 @@ import { SandboxLogStore } from "../sandbox/log-store";
 import type { EnvironmentSandboxConfig } from "../sandbox/manager";
 import { EnvironmentService } from "../services/environment.service";
 import { EventJournal } from "../services/event-journal";
-import { ExtensionConfigService } from "./../services/extension-config.service";
+import { ExtensionConfigService } from "../services/extension-config.service";
 import { ExtensionManifestService } from "../services/extension-manifest.service";
 import { GitHubService } from "../services/github.service";
 import { PackageCatalogService } from "../services/package-catalog.service";
@@ -25,8 +26,10 @@ describe("Sessions Routes", () => {
   let db: AppDatabase;
   let sqlite: ReturnType<typeof createTestDatabase>["sqlite"];
   let services: AppServices;
+  let tempDirs: string[];
 
   beforeEach(() => {
+    tempDirs = [];
     const result = createTestDatabase();
     db = result.db;
     sqlite = result.sqlite;
@@ -63,6 +66,9 @@ describe("Sessions Routes", () => {
   });
 
   afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
     sqlite.close();
   });
 
@@ -181,6 +187,82 @@ describe("Sessions Routes", () => {
       expect(json.data.mode).toBe("code");
       expect(json.data.repoId).toBe("owner/repo");
       expect(json.data.environmentId).toBeDefined();
+    });
+
+    it("creates local code session using repoId as a filesystem path", async () => {
+      const workspace = mkdtempSync(join(tmpdir(), "pi-relay-local-"));
+      tempDirs.push(workspace);
+      const localEnv = services.environmentService.create({
+        name: "Local",
+        sandboxType: "local",
+        config: {},
+      });
+
+      const app = createApp({ services });
+      const res = await app.request("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "code",
+          repoId: workspace,
+          environmentId: localEnv.id,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data.mode).toBe("code");
+      expect(json.data.repoId).toBeNull();
+      expect(json.data.repoPath).toBe(workspace);
+      expect(json.data.environmentId).toBe(localEnv.id);
+    });
+
+    it("allows local code session without repoId and uses temp workspace", async () => {
+      const localEnv = services.environmentService.create({
+        name: "Local",
+        sandboxType: "local",
+        config: {},
+      });
+
+      const app = createApp({ services });
+      const res = await app.request("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "code",
+          environmentId: localEnv.id,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data.mode).toBe("code");
+      expect(json.data.repoId).toBeNull();
+      expect(json.data.repoPath).toBeNull();
+      expect(json.data.environmentId).toBe(localEnv.id);
+    });
+
+    it("rejects nonexistent local workspace paths", async () => {
+      const localEnv = services.environmentService.create({
+        name: "Local",
+        sandboxType: "local",
+        config: {},
+      });
+
+      const app = createApp({ services });
+      const res = await app.request("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "code",
+          repoId: "/definitely/missing/path",
+          environmentId: localEnv.id,
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("Local workspace does not exist");
     });
 
     it("rejects session with nonexistent environmentId", async () => {

--- a/server/relay/src/routes/sessions.ts
+++ b/server/relay/src/routes/sessions.ts
@@ -3,9 +3,10 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
-import { basename, extname, join } from "node:path";
+import { basename, extname, join, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppEnv } from "../app";
@@ -242,6 +243,27 @@ function getSessionExportPath(
   );
 }
 
+function resolveLocalWorkspacePath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Local workspace path is empty");
+  }
+
+  const expanded = trimmed.startsWith("~/")
+    ? join(process.env.HOME ?? "", trimmed.slice(2))
+    : trimmed;
+  const resolved = resolve(expanded);
+
+  if (!existsSync(resolved)) {
+    throw new Error(`Local workspace does not exist: ${resolved}`);
+  }
+  if (!statSync(resolved).isDirectory()) {
+    throw new Error(`Local workspace is not a directory: ${resolved}`);
+  }
+
+  return resolved;
+}
+
 export function sessionsRoutes(): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const logger = createLogger("sessions");
@@ -282,19 +304,13 @@ export function sessionsRoutes(): Hono<AppEnv> {
       );
     }
 
-    // Code mode requires repoId
-    if (body.mode === "code" && !body.repoId) {
-      return c.json(
-        { data: null, error: "repoId is required for code mode" },
-        400,
-      );
-    }
 
     // Resolve environment, repo, and sandbox provider
     let environmentId: string | undefined;
     let sandboxProvider: SandboxProviderType;
     let repoUrl: string | undefined;
     let repoBranch: string | undefined;
+    let repoPath: string | undefined;
     let desiredBranchName: string | undefined;
     let githubToken: string | undefined;
     let resolvedGitAuthorName: string | undefined;
@@ -342,9 +358,33 @@ export function sessionsRoutes(): Hono<AppEnv> {
     const resolvedSystemPrompt = body.systemPrompt ?? chatOnlyPromptProfile;
 
     if (body.mode === "code") {
-      const githubService = c.get("githubService");
+      if (sandboxProvider === "local") {
+        if (body.repoId) {
+          try {
+            repoPath = resolveLocalWorkspacePath(body.repoId);
+          } catch (err) {
+            return c.json(
+              {
+                data: null,
+                error:
+                  err instanceof Error
+                    ? err.message
+                    : "Invalid local workspace path",
+              },
+              400,
+            );
+          }
+        }
+      } else {
+        const githubService = c.get("githubService");
 
-      if (body.repoId) {
+        if (!body.repoId) {
+          return c.json(
+            { data: null, error: "repoId is required for code mode" },
+            400,
+          );
+        }
+
         let repo = repoService.get(body.repoId);
         if (!repo) {
           try {
@@ -404,7 +444,8 @@ export function sessionsRoutes(): Hono<AppEnv> {
       // Create session in database
       const session = sessionService.create({
         mode: body.mode,
-        repoId: body.repoId,
+        repoId: sandboxProvider === "local" ? undefined : body.repoId,
+        repoPath,
         branchName: repoBranch,
         environmentId,
         modelProvider: body.modelProvider,
@@ -456,7 +497,8 @@ export function sessionsRoutes(): Hono<AppEnv> {
                 sandboxType: sandboxProvider as
                   | "docker"
                   | "cloudflare"
-                  | "gondolin",
+                  | "gondolin"
+                  | "local",
               },
               {
                 repoUrl,

--- a/server/relay/src/routes/settings.ts
+++ b/server/relay/src/routes/settings.ts
@@ -105,10 +105,21 @@ export function settingsRoutes(): Hono<AppEnv> {
       // Gondolin not available
     }
 
+    // Check local availability
+    let localAvailable = false;
+    try {
+      localAvailable = await sandboxManager.isProviderAvailable({
+        sandboxType: "local",
+      });
+    } catch {
+      // Local pi not available
+    }
+
     return c.json({
       data: {
         docker: { available: dockerAvailable },
         gondolin: { available: gondolinAvailable },
+        local: { available: localAvailable },
       },
       error: null,
     });

--- a/server/relay/src/sandbox/cloudflare.test.ts
+++ b/server/relay/src/sandbox/cloudflare.test.ts
@@ -471,6 +471,7 @@ describe("SandboxManager cloudflare wiring", () => {
       {
         docker: { sessionDataDir: "/tmp/test", secretsBaseDir: "/tmp/test" },
         gondolin: { sessionDataDir: "/tmp/test" },
+        local: { sessionDataDir: "/tmp/test" },
       },
       secretsService,
     );
@@ -490,6 +491,7 @@ describe("SandboxManager cloudflare wiring", () => {
       {
         docker: { sessionDataDir: "/tmp/test", secretsBaseDir: "/tmp/test" },
         gondolin: { sessionDataDir: "/tmp/test" },
+        local: { sessionDataDir: "/tmp/test" },
       },
       secretsService,
     );

--- a/server/relay/src/sandbox/git-config.ts
+++ b/server/relay/src/sandbox/git-config.ts
@@ -10,6 +10,8 @@ export interface GitConfigOptions {
   gitAuthorEmail?: string;
   /** Path prefix for the credential helper inside the sandbox (e.g. "/git" or "/data/git") */
   credentialHelperPath: string;
+  /** Git safe.directory entries to write to the config. Defaults to /workspace. */
+  safeDirectories?: string[];
 }
 
 /**
@@ -40,13 +42,13 @@ export function writeGitConfig(gitDir: string, opts: GitConfigOptions): void {
 
   const name = opts.gitAuthorName || DEFAULT_GIT_AUTHOR_NAME;
   const email = opts.gitAuthorEmail || DEFAULT_GIT_AUTHOR_EMAIL;
-  const lines = [
-    "[user]",
-    `\tname = "${name}"`,
-    `\temail = "${email}"`,
-    "[safe]",
-    "\tdirectory = /workspace",
-  ];
+  const safeDirectories = opts.safeDirectories?.length
+    ? opts.safeDirectories
+    : ["/workspace"];
+  const lines = ["[user]", `\tname = "${name}"`, `\temail = "${email}"`];
+  for (const safeDirectory of safeDirectories) {
+    lines.push("[safe]", `\tdirectory = ${safeDirectory}`);
+  }
   if (githubToken) {
     lines.push(
       "[credential]",

--- a/server/relay/src/sandbox/local.ts
+++ b/server/relay/src/sandbox/local.ts
@@ -1,0 +1,720 @@
+import {
+  type ChildProcessWithoutNullStreams,
+  exec as execCallback,
+  spawn,
+} from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import process from "node:process";
+import readline from "node:readline";
+import { promisify } from "node:util";
+import type { IPty } from "node-pty";
+import { spawn as spawnPty } from "node-pty";
+import { createLogger } from "../lib/logger";
+import { writeGitConfig } from "./git-config";
+import type { SandboxLogStore } from "./log-store";
+import type {
+  CleanupResult,
+  CreateSandboxOptions,
+  PtyHandle,
+  SandboxChannel,
+  SandboxHandle,
+  SandboxInfo,
+  SandboxProvider,
+  SandboxProviderCapabilities,
+  SandboxStatus,
+} from "./types";
+
+const logger = createLogger("local");
+const execAsync = promisify(execCallback);
+
+const NATIVE_BRIDGE_EXTENSION = resolve(
+  import.meta.dirname,
+  "../../extensions/native-bridge.ts",
+);
+
+const DEFAULT_PI_BINARY = "pi";
+const DEFAULT_PROVIDER_ID_SENTINEL = "_";
+
+export interface LocalProviderConfig {
+  sessionDataDir: string;
+  piBinaryPath?: string;
+}
+
+function encodeWorkspacePath(workspacePath?: string): string {
+  const value = workspacePath ?? "";
+  return value
+    ? Buffer.from(value, "utf8").toString("base64url")
+    : DEFAULT_PROVIDER_ID_SENTINEL;
+}
+
+function decodeWorkspacePath(encoded: string): string | undefined {
+  if (!encoded || encoded === DEFAULT_PROVIDER_ID_SENTINEL) {
+    return undefined;
+  }
+  return Buffer.from(encoded, "base64url").toString("utf8");
+}
+
+function buildProviderId(sessionId: string, workspacePath?: string): string {
+  return `local:${sessionId}:${encodeWorkspacePath(workspacePath)}`;
+}
+
+function parseProviderId(providerId: string): {
+  sessionId: string;
+  workspacePath?: string;
+} {
+  const [provider, sessionId, encodedWorkspacePath] = providerId.split(":");
+  if (provider !== "local" || !sessionId || !encodedWorkspacePath) {
+    throw new Error(`Invalid local provider ID: ${providerId}`);
+  }
+  return {
+    sessionId,
+    workspacePath: decodeWorkspacePath(encodedWorkspacePath),
+  };
+}
+
+function getLocalShell(): { file: string; args: string[] } {
+  if (process.platform === "win32") {
+    const powershell = process.env.ComSpec || "powershell.exe";
+    return { file: powershell, args: [] };
+  }
+
+  // Try $SHELL first, then common fallbacks.
+  const candidates = [
+    process.env.SHELL?.trim(),
+    "/bin/zsh",
+    "/bin/bash",
+    "/bin/sh",
+  ].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      const name = basename(candidate);
+      const loginArgs =
+        name === "bash" || name === "zsh" || name === "fish" ? ["-l"] : [];
+      return { file: candidate, args: loginArgs };
+    }
+  }
+
+  // Last resort: rely on PATH resolution.
+  return { file: "sh", args: [] };
+}
+
+export class LocalSandboxProvider implements SandboxProvider {
+  readonly name = "local";
+  readonly capabilities: SandboxProviderCapabilities = {
+    losslessPause: false,
+    persistentDisk: true,
+  };
+
+  private config: Required<Pick<LocalProviderConfig, "sessionDataDir">> & {
+    piBinaryPath?: string;
+  };
+  private handles = new Map<string, LocalSandboxHandle>();
+  private logStore: SandboxLogStore | null;
+
+  constructor(config: LocalProviderConfig, logStore?: SandboxLogStore) {
+    this.config = {
+      sessionDataDir: config.sessionDataDir,
+      piBinaryPath: config.piBinaryPath?.trim() || undefined,
+    };
+    this.logStore = logStore ?? null;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    const piBinary = this.config.piBinaryPath ?? DEFAULT_PI_BINARY;
+
+    try {
+      const child = spawn(piBinary, ["--version"], {
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+
+      const exitCode = await new Promise<number>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("exit", (code) => resolve(code ?? 1));
+      });
+
+      return exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async createSandbox(options: CreateSandboxOptions): Promise<SandboxHandle> {
+    const workspacePath = options.workspacePath?.trim() || undefined;
+    const providerId = buildProviderId(options.sessionId, workspacePath);
+    const existing = this.handles.get(providerId);
+    if (
+      existing &&
+      existing.status !== "stopped" &&
+      existing.status !== "error"
+    ) {
+      return existing;
+    }
+
+    const handle = new LocalSandboxHandle({
+      sessionId: options.sessionId,
+      providerId,
+      workspacePath,
+      sessionDataDir: this.config.sessionDataDir,
+      piBinaryPath: this.config.piBinaryPath ?? DEFAULT_PI_BINARY,
+      baseEnv: options.env,
+      nativeToolsEnabled: options.nativeToolsEnabled ?? false,
+      githubToken: options.githubToken,
+      gitAuthorName: options.gitAuthorName,
+      gitAuthorEmail: options.gitAuthorEmail,
+      logStore: this.logStore ?? undefined,
+    });
+
+    await handle.resume(
+      options.secrets,
+      options.githubToken,
+      options.secretMaterial,
+    );
+    this.handles.set(providerId, handle);
+    return handle;
+  }
+
+  async getSandbox(providerId: string): Promise<SandboxHandle> {
+    const existing = this.handles.get(providerId);
+    if (existing) {
+      return existing;
+    }
+
+    // Handle lost (e.g., server restart). Reconstruct from providerId.
+    // The session data dir persists on disk, so pi --continue picks up
+    // the existing conversation. resume() will spawn the process.
+    const { sessionId, workspacePath } = parseProviderId(providerId);
+    logger.info(
+      { sessionId, providerId },
+      "reconstructing local sandbox handle after restart",
+    );
+
+    const handle = new LocalSandboxHandle({
+      sessionId,
+      providerId,
+      workspacePath,
+      sessionDataDir: this.config.sessionDataDir,
+      piBinaryPath: this.config.piBinaryPath ?? DEFAULT_PI_BINARY,
+      logStore: this.logStore ?? undefined,
+    });
+
+    this.handles.set(providerId, handle);
+    return handle;
+  }
+
+  async listSandboxes(): Promise<SandboxInfo[]> {
+    return Array.from(this.handles.values()).map((handle) => ({
+      sessionId: handle.sessionId,
+      providerId: handle.providerId,
+      status: handle.status,
+      createdAt: handle.createdAt,
+    }));
+  }
+
+  async cleanup(): Promise<CleanupResult> {
+    let sandboxesRemoved = 0;
+    for (const [providerId, handle] of this.handles) {
+      if (handle.status === "stopped" || handle.status === "error") {
+        this.handles.delete(providerId);
+        sandboxesRemoved += 1;
+      }
+    }
+    return { sandboxesRemoved, artifactsRemoved: 0 };
+  }
+}
+
+interface LocalHandleOptions {
+  sessionId: string;
+  providerId: string;
+  workspacePath?: string;
+  sessionDataDir: string;
+  piBinaryPath: string;
+  baseEnv?: Record<string, string>;
+  nativeToolsEnabled?: boolean;
+  githubToken?: string;
+  gitAuthorName?: string;
+  gitAuthorEmail?: string;
+  logStore?: SandboxLogStore;
+}
+
+class LocalSandboxHandle implements SandboxHandle {
+  readonly sessionId: string;
+  readonly providerId: string;
+  readonly createdAt: string;
+
+  private _status: SandboxStatus = "stopped";
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private currentChannel: LocalSandboxChannel | null = null;
+  private activePtys = new Set<LocalPtyHandle>();
+  private statusHandlers = new Set<(status: SandboxStatus) => void>();
+  private sessionDir: string;
+  private workspacePath: string;
+  private agentDir: string;
+  private gitDir: string;
+  private workspaceManagedBySession: boolean;
+  private piBinaryPath: string;
+  private baseEnv: Record<string, string>;
+  private runtimeEnv: Record<string, string> = {};
+  private nativeToolsEnabled: boolean;
+  private githubToken?: string;
+  private gitAuthorName?: string;
+  private gitAuthorEmail?: string;
+  private pendingExitStatus: SandboxStatus | null = null;
+  private logStore?: SandboxLogStore;
+
+  constructor(options: LocalHandleOptions) {
+    this.sessionId = options.sessionId;
+    this.providerId = options.providerId;
+    this.createdAt = new Date().toISOString();
+    this.sessionDir = join(options.sessionDataDir, options.sessionId);
+    this.workspaceManagedBySession = !options.workspacePath;
+    this.workspacePath =
+      options.workspacePath ?? join(this.sessionDir, "workspace");
+    this.agentDir = join(this.sessionDir, "agent");
+    this.gitDir = join(this.sessionDir, "git");
+    this.piBinaryPath = options.piBinaryPath;
+    this.baseEnv = options.baseEnv ?? {};
+    this.nativeToolsEnabled = options.nativeToolsEnabled ?? false;
+    this.githubToken = options.githubToken;
+    this.gitAuthorName = options.gitAuthorName;
+    this.gitAuthorEmail = options.gitAuthorEmail;
+    this.logStore = options.logStore;
+  }
+
+  get status(): SandboxStatus {
+    return this._status;
+  }
+
+  async resume(
+    secrets?: Record<string, string>,
+    githubToken?: string,
+    _secretMaterial?: import("./types").SandboxSecretMaterial,
+  ): Promise<void> {
+    if (githubToken !== undefined) {
+      this.githubToken = githubToken;
+    }
+
+    this.ensureDirs();
+    this.writeGitConfig();
+    this.runtimeEnv = this.buildRuntimeEnv(secrets, this.githubToken);
+
+    if (this.child && this._status === "running") {
+      return;
+    }
+
+    await this.spawnPi();
+  }
+
+  async exec(command: string): Promise<{ exitCode: number; output: string }> {
+    const env = this.runtimeEnv;
+    try {
+      const { stdout, stderr } = await execAsync(command, {
+        cwd: this.workspacePath,
+        env,
+      });
+      return { exitCode: 0, output: `${stdout}${stderr}` };
+    } catch (error) {
+      if (error instanceof Error) {
+        const execError = error as Error & {
+          code?: number;
+          stdout?: string;
+          stderr?: string;
+        };
+        return {
+          exitCode: execError.code ?? 1,
+          output: `${execError.stdout ?? ""}${execError.stderr ?? ""}`,
+        };
+      }
+      throw error;
+    }
+  }
+
+  async openPty(cols: number, rows: number): Promise<PtyHandle> {
+    if (this._status !== "running") {
+      throw new Error("Cannot openPty: local sandbox is not running");
+    }
+
+    if (Object.keys(this.runtimeEnv).length === 0) {
+      this.ensureDirs();
+      this.writeGitConfig();
+      this.runtimeEnv = this.buildRuntimeEnv(undefined, this.githubToken);
+    }
+
+    const shell = getLocalShell();
+    const env = {
+      ...this.runtimeEnv,
+      TERM: this.runtimeEnv.TERM || "xterm-256color",
+      COLORTERM: this.runtimeEnv.COLORTERM || "truecolor",
+    };
+
+    const pty = spawnPty(shell.file, shell.args, {
+      name: env.TERM,
+      cwd: this.workspacePath,
+      env,
+      cols,
+      rows,
+    });
+
+    const handle = new LocalPtyHandle(pty, () => {
+      this.activePtys.delete(handle);
+    });
+    this.activePtys.add(handle);
+    return handle;
+  }
+
+  async attach(): Promise<SandboxChannel> {
+    if (!this.child || this._status !== "running") {
+      throw new Error("Cannot attach: local sandbox is not running");
+    }
+
+    if (this.currentChannel) {
+      this.currentChannel.close();
+      this.currentChannel = null;
+    }
+
+    const channel = new LocalSandboxChannel(
+      this.child,
+      this.sessionId,
+      this.logStore,
+    );
+    this.currentChannel = channel;
+    return channel;
+  }
+
+  async pause(): Promise<void> {
+    await this.stopChild("paused");
+  }
+
+  async terminate(): Promise<void> {
+    await this.stopChild("stopped");
+  }
+
+  onStatusChange(handler: (status: SandboxStatus) => void): () => void {
+    this.statusHandlers.add(handler);
+    return () => this.statusHandlers.delete(handler);
+  }
+
+  private ensureDirs(): void {
+    mkdirSync(this.sessionDir, { recursive: true });
+    if (this.workspaceManagedBySession) {
+      mkdirSync(this.workspacePath, { recursive: true });
+    } else if (
+      !existsSync(this.workspacePath) ||
+      !statSync(this.workspacePath).isDirectory()
+    ) {
+      throw new Error(`Local workspace does not exist: ${this.workspacePath}`);
+    }
+    mkdirSync(this.agentDir, { recursive: true });
+    mkdirSync(this.gitDir, { recursive: true });
+    mkdirSync(join(this.agentDir, "data"), { recursive: true });
+    mkdirSync(join(this.agentDir, "config"), { recursive: true });
+    mkdirSync(join(this.agentDir, "cache"), { recursive: true });
+    mkdirSync(join(this.agentDir, "state"), { recursive: true });
+    mkdirSync(join(this.agentDir, "npm"), { recursive: true });
+
+    // Copy the host's auth.json so pi can use OAuth-gated providers
+    // (e.g. Anthropic). Without this, the isolated agent dir has no
+    // OAuth tokens and pi rejects those providers as unavailable.
+    this.copyHostAuth();
+  }
+
+  /**
+   * Copy the host's auth.json into this sandbox's agent dir.
+   * No-op if the host file doesn't exist or the sandbox already has one.
+   */
+  private copyHostAuth(): void {
+    const dest = join(this.agentDir, "auth.json");
+    if (existsSync(dest)) return;
+
+    const hostAgentDir =
+      process.env.PI_CODING_AGENT_DIR ||
+      join(process.env.HOME || process.env.USERPROFILE || "", ".pi", "agent");
+    const src = join(hostAgentDir, "auth.json");
+    if (!existsSync(src)) return;
+
+    try {
+      copyFileSync(src, dest);
+      logger.debug({ sessionId: this.sessionId }, "copied host auth.json to sandbox");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn({ sessionId: this.sessionId, err: message }, "failed to copy host auth.json");
+    }
+  }
+
+  private writeGitConfig(): void {
+    writeGitConfig(this.gitDir, {
+      githubToken: this.githubToken,
+      gitAuthorName: this.gitAuthorName,
+      gitAuthorEmail: this.gitAuthorEmail,
+      credentialHelperPath: this.gitDir,
+      safeDirectories: [this.workspacePath],
+    });
+  }
+
+  private buildRuntimeEnv(
+    secrets?: Record<string, string>,
+    githubToken?: string,
+  ): Record<string, string> {
+    const env: Record<string, string> = {
+      ...Object.fromEntries(
+        Object.entries(process.env).filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        ),
+      ),
+      ...this.baseEnv,
+      ...(secrets ?? {}),
+      PI_SESSION_ID: this.sessionId,
+      PI_CODING_AGENT_DIR: this.agentDir,
+      npm_config_prefix: join(this.agentDir, "npm"),
+      GIT_CONFIG_GLOBAL: join(this.gitDir, "gitconfig"),
+      XDG_DATA_HOME: join(this.agentDir, "data"),
+      XDG_CONFIG_HOME: join(this.agentDir, "config"),
+      XDG_CACHE_HOME: join(this.agentDir, "cache"),
+      XDG_STATE_HOME: join(this.agentDir, "state"),
+    };
+
+    if (githubToken) {
+      env.GH_TOKEN = githubToken;
+    }
+
+    return env;
+  }
+
+  private async spawnPi(): Promise<void> {
+    this.currentChannel?.close();
+    this.currentChannel = null;
+    this.setStatus("creating");
+
+    const args = ["--mode", "rpc", "--continue"];
+    if (this.nativeToolsEnabled) {
+      args.push("-e", NATIVE_BRIDGE_EXTENSION);
+    }
+
+    const child = spawn(this.piBinaryPath, args, {
+      cwd: this.workspacePath,
+      env: this.runtimeEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.child = child;
+
+    await new Promise<void>((resolve, reject) => {
+      let started = false;
+
+      child.once("spawn", () => {
+        started = true;
+        this.setStatus("running");
+        resolve();
+      });
+
+      child.once("error", (err) => {
+        if (!started) {
+          this.child = null;
+          this.setStatus("error");
+          reject(new Error(`Failed to spawn pi: ${err.message}`));
+          return;
+        }
+        logger.error(
+          { err, sessionId: this.sessionId },
+          "local pi process error",
+        );
+      });
+
+      child.once("exit", (code, signal) => {
+        const status = this.pendingExitStatus ?? "stopped";
+        this.pendingExitStatus = null;
+        if (this.child === child) {
+          this.child = null;
+        }
+        this.currentChannel?.notifyProcessExit(
+          signal ? `pi exited (${signal})` : `pi exited (${code ?? 0})`,
+        );
+        this.currentChannel = null;
+        this.setStatus(status);
+
+        if (!started) {
+          reject(
+            new Error(
+              signal
+                ? `pi exited before startup (${signal})`
+                : `pi exited before startup (${code ?? 0})`,
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  private async stopChild(nextStatus: SandboxStatus): Promise<void> {
+    this.closeActivePtys();
+
+    const child = this.child;
+    if (!child) {
+      this.setStatus(nextStatus);
+      return;
+    }
+
+    this.currentChannel?.close();
+    this.currentChannel = null;
+    this.pendingExitStatus = nextStatus;
+
+    const exited = new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+    });
+
+    child.kill("SIGTERM");
+    const forced = setTimeout(() => {
+      if (this.child === child) {
+        child.kill("SIGKILL");
+      }
+    }, 5_000);
+
+    await exited;
+    clearTimeout(forced);
+  }
+
+  private closeActivePtys(): void {
+    for (const pty of this.activePtys) {
+      pty.close();
+    }
+    this.activePtys.clear();
+  }
+
+  private setStatus(status: SandboxStatus): void {
+    if (this._status === status) return;
+    this._status = status;
+    for (const handler of this.statusHandlers) {
+      handler(status);
+    }
+  }
+}
+
+class LocalPtyHandle implements PtyHandle {
+  private closed = false;
+  private dataHandlers = new Set<(data: string) => void>();
+  private exitHandlers = new Set<(exitCode: number) => void>();
+  private disposeOnData: { dispose(): void } | null = null;
+  private disposeOnExit: { dispose(): void } | null = null;
+
+  constructor(
+    private pty: IPty,
+    private onDispose: () => void,
+  ) {
+    this.disposeOnData = this.pty.onData((data) => {
+      for (const handler of this.dataHandlers) {
+        handler(data);
+      }
+    });
+
+    this.disposeOnExit = this.pty.onExit(({ exitCode }) => {
+      for (const handler of this.exitHandlers) {
+        handler(exitCode);
+      }
+      this.close();
+    });
+  }
+
+  write(data: string): void {
+    if (this.closed) return;
+    this.pty.write(data);
+  }
+
+  onData(handler: (data: string) => void): () => void {
+    this.dataHandlers.add(handler);
+    return () => this.dataHandlers.delete(handler);
+  }
+
+  onExit(handler: (exitCode: number) => void): () => void {
+    this.exitHandlers.add(handler);
+    return () => this.exitHandlers.delete(handler);
+  }
+
+  resize(cols: number, rows: number): void {
+    if (this.closed) return;
+    this.pty.resize(cols, rows);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.disposeOnData?.dispose();
+    this.disposeOnExit?.dispose();
+    this.disposeOnData = null;
+    this.disposeOnExit = null;
+    try {
+      this.pty.kill();
+    } catch {
+      // Process may already be dead.
+    }
+    this.dataHandlers.clear();
+    this.exitHandlers.clear();
+    this.onDispose();
+  }
+}
+
+class LocalSandboxChannel implements SandboxChannel {
+  private closed = false;
+  private messageHandlers = new Set<(message: string) => void>();
+  private closeHandlers = new Set<(reason?: string) => void>();
+  private stdoutRl: readline.Interface;
+  private stderrRl: readline.Interface;
+
+  constructor(
+    private child: ChildProcessWithoutNullStreams,
+    private sessionId: string,
+    private logStore?: SandboxLogStore,
+  ) {
+    this.stdoutRl = readline.createInterface({ input: child.stdout });
+    this.stderrRl = readline.createInterface({ input: child.stderr });
+
+    this.stdoutRl.on("line", (line) => {
+      if (this.closed) return;
+      for (const handler of this.messageHandlers) {
+        handler(line);
+      }
+    });
+
+    this.stderrRl.on("line", (line) => {
+      if (!line.trim()) return;
+      logger.debug({ sessionId: this.sessionId, line }, "local sandbox stderr");
+      this.logStore?.append(this.sessionId, line);
+    });
+  }
+
+  send(message: string): void {
+    if (this.closed) return;
+    this.child.stdin.write(`${message}\n`);
+  }
+
+  onMessage(handler: (message: string) => void): () => void {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onClose(handler: (reason?: string) => void): () => void {
+    this.closeHandlers.add(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.stdoutRl.close();
+    this.stderrRl.close();
+    this.messageHandlers.clear();
+    this.closeHandlers.clear();
+  }
+
+  notifyProcessExit(reason?: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const handler of this.closeHandlers) {
+      handler(reason);
+    }
+    this.stdoutRl.close();
+    this.stderrRl.close();
+    this.messageHandlers.clear();
+    this.closeHandlers.clear();
+  }
+}

--- a/server/relay/src/sandbox/manager.ts
+++ b/server/relay/src/sandbox/manager.ts
@@ -4,6 +4,7 @@ import type { SecretsService } from "../services/secrets.service";
 import { CloudflareSandboxProvider } from "./cloudflare";
 import { DockerSandboxProvider } from "./docker";
 import { GondolinSandboxProvider } from "./gondolin";
+import { LocalSandboxProvider } from "./local";
 import type { SandboxLogStore } from "./log-store";
 import { MockSandboxProvider } from "./mock";
 import type { SandboxProviderType } from "./provider-types";
@@ -31,7 +32,7 @@ const log = createLogger("sandbox");
  * Callers resolve secrets before passing this to the manager.
  */
 export interface EnvironmentSandboxConfig {
-  sandboxType: "docker" | "cloudflare" | "gondolin";
+  sandboxType: "docker" | "cloudflare" | "gondolin" | "local";
   /** Docker image name (for docker type) */
   image?: string;
   /** Cloudflare Worker URL (for cloudflare type) */
@@ -42,6 +43,8 @@ export interface EnvironmentSandboxConfig {
   imagePath?: string;
   /** Non-secret environment variables resolved from the environment config. */
   env?: Record<string, string>;
+  /** Optional explicit path to the pi executable for local sandboxes. */
+  piBinaryPath?: string;
 }
 
 export interface SandboxManagerConfig {
@@ -54,6 +57,9 @@ export interface SandboxManagerConfig {
     secretsBaseDir: string;
   };
   gondolin: {
+    sessionDataDir: string;
+  };
+  local: {
     sessionDataDir: string;
   };
   /** Optional log store for buffering sandbox stderr lines. */
@@ -138,6 +144,24 @@ export class SandboxManager {
           {
             sessionDataDir: this.config.gondolin.sessionDataDir,
             imagePath,
+          },
+          this.config.logStore,
+        );
+        this.providerCache.set(cacheKey, provider);
+      }
+      return provider;
+    }
+
+    if (envConfig.sandboxType === "local") {
+      const piBinaryPath = envConfig.piBinaryPath?.trim() || "pi";
+      const cacheKey = `local:${piBinaryPath}`;
+
+      let provider = this.providerCache.get(cacheKey);
+      if (!provider) {
+        provider = new LocalSandboxProvider(
+          {
+            sessionDataDir: this.config.local.sessionDataDir,
+            piBinaryPath,
           },
           this.config.logStore,
         );
@@ -240,7 +264,7 @@ export class SandboxManager {
    * Fetches fresh secrets from the secrets service.
    */
   async resolveSecretMaterial(
-    providerType: "docker" | "cloudflare" | "gondolin" | "mock",
+    providerType: "docker" | "cloudflare" | "gondolin" | "mock" | "local",
   ): Promise<SandboxSecretMaterial> {
     const material = await this.secretsService.getSecretMaterial(providerType);
     return {
@@ -267,7 +291,12 @@ export class SandboxManager {
   ): Promise<SandboxHandle> {
     const provider = this.getProvider(envConfig);
     const material = await this.resolveSecretMaterial(
-      envConfig.sandboxType as "docker" | "cloudflare" | "gondolin" | "mock",
+      envConfig.sandboxType as
+        | "docker"
+        | "cloudflare"
+        | "gondolin"
+        | "mock"
+        | "local",
     );
     const mergedEnv = { ...(envConfig.env ?? {}), ...(options?.env ?? {}) };
     const mergedDirectEnv = { ...material.directEnv, ...mergedEnv };
@@ -351,7 +380,7 @@ export class SandboxManager {
       envConfig,
     );
     const material = await this.resolveSecretMaterial(
-      providerType as "docker" | "cloudflare" | "gondolin" | "mock",
+      providerType as "docker" | "cloudflare" | "gondolin" | "mock" | "local",
     );
     const mergedDirectEnv = {
       ...material.directEnv,
@@ -461,13 +490,19 @@ export async function resolveEnvConfig(
     secretId?: string;
     imagePath?: string;
     envVars?: Array<{ key: string; value: string }>;
+    piBinaryPath?: string;
   };
 
   const result: EnvironmentSandboxConfig = {
-    sandboxType: env.sandboxType as "docker" | "cloudflare" | "gondolin",
+    sandboxType: env.sandboxType as
+      | "docker"
+      | "cloudflare"
+      | "gondolin"
+      | "local",
     image: config.image,
     workerUrl: config.workerUrl,
     imagePath: config.imagePath,
+    piBinaryPath: config.piBinaryPath,
     env:
       config.envVars && config.envVars.length > 0
         ? Object.fromEntries(

--- a/server/relay/src/sandbox/provider-types.ts
+++ b/server/relay/src/sandbox/provider-types.ts
@@ -4,7 +4,12 @@
  */
 
 /** Supported sandbox provider backends. */
-export type SandboxProviderType = "mock" | "docker" | "cloudflare" | "gondolin";
+export type SandboxProviderType =
+  | "mock"
+  | "docker"
+  | "cloudflare"
+  | "gondolin"
+  | "local";
 
 /** All supported sandbox provider types. Used as default and for status checks. */
 export const ALL_PROVIDER_TYPES: SandboxProviderType[] = [
@@ -12,6 +17,7 @@ export const ALL_PROVIDER_TYPES: SandboxProviderType[] = [
   "docker",
   "cloudflare",
   "gondolin",
+  "local",
 ];
 
 /** Provider types shown in UI. Mock is internal-only. */
@@ -19,6 +25,7 @@ export const USER_FACING_PROVIDER_TYPES: readonly SandboxProviderType[] = [
   "docker",
   "cloudflare",
   "gondolin",
+  "local",
 ] as const;
 
 /** Provider-neutral resource tiers. Each provider maps these to its own limits. */

--- a/server/relay/src/sandbox/types.ts
+++ b/server/relay/src/sandbox/types.ts
@@ -166,6 +166,9 @@ export interface CreateSandboxOptions {
   repoUrl?: string;
   repoBranch?: string;
 
+  /** Existing host workspace directory to use directly instead of cloning. */
+  workspacePath?: string;
+
   /** GitHub PAT for git push and private repo clone */
   githubToken?: string;
 

--- a/server/relay/src/services/environment.service.ts
+++ b/server/relay/src/services/environment.service.ts
@@ -9,6 +9,7 @@ import type { SandboxResourceTier } from "../sandbox/provider-types";
  * - Docker: image (required), resourceTier (optional)
  * - Cloudflare: workerUrl (required), resourceTier (optional)
  * - Gondolin: imagePath (optional), resourceTier (optional)
+ * - Local: piBinaryPath (optional), resourceTier unused
  */
 /**
  * Per-environment config stored as JSON in the environments table.
@@ -16,6 +17,7 @@ import type { SandboxResourceTier } from "../sandbox/provider-types";
  * - Docker: image (required), resourceTier (optional)
  * - Cloudflare: workerUrl (required), secretId (required, references secrets table), resourceTier (optional)
  * - Gondolin: imagePath (optional), resourceTier (optional)
+ * - Local: piBinaryPath (optional)
  */
 export interface EnvironmentConfig {
   /** Docker image name (required for docker type) */
@@ -26,6 +28,8 @@ export interface EnvironmentConfig {
   secretId?: string;
   /** Optional custom guest assets directory for Gondolin environments. */
   imagePath?: string;
+  /** Optional explicit path to the pi executable for local environments. */
+  piBinaryPath?: string;
   resourceTier?: SandboxResourceTier;
   /** Idle timeout in seconds before the reaper idles the session. Default: 3600 (1 hour). */
   idleTimeoutSeconds?: number;
@@ -36,7 +40,7 @@ export interface EnvironmentConfig {
   envVars?: Array<{ key: string; value: string }>;
 }
 
-export type SandboxType = "docker" | "cloudflare" | "gondolin";
+export type SandboxType = "docker" | "cloudflare" | "gondolin" | "local";
 
 export interface CreateEnvironmentParams {
   name: string;

--- a/server/relay/src/services/models-introspection.service.test.ts
+++ b/server/relay/src/services/models-introspection.service.test.ts
@@ -38,6 +38,9 @@ describe("ModelsIntrospectionService", () => {
         gondolin: {
           sessionDataDir: "/tmp/pi-test-sessions",
         },
+        local: {
+          sessionDataDir: "/tmp/pi-test-sessions",
+        },
       },
       mockSecrets,
     );

--- a/server/relay/src/services/models-introspection.service.ts
+++ b/server/relay/src/services/models-introspection.service.ts
@@ -1,5 +1,6 @@
-import { rmSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import process from "node:process";
 import { createLogger } from "../lib/logger";
 import type {
   EnvironmentSandboxConfig,
@@ -98,6 +99,10 @@ export class ModelsIntrospectionService {
         "code",
       );
       log.debug({ sessionId, packages }, "wrote extension settings");
+
+      if (this.envConfig.sandboxType === "local") {
+        this.copyHostAuth(sessionId);
+      }
 
       // Create ephemeral sandbox with real provider (manager resolves secrets)
       log.debug({ sessionId }, "creating sandbox");
@@ -217,6 +222,33 @@ export class ModelsIntrospectionService {
       } catch {
         // Best-effort cleanup
       }
+    }
+  }
+
+  private copyHostAuth(sessionId: string): void {
+    const hostAgentDir =
+      process.env.PI_CODING_AGENT_DIR ||
+      join(
+        process.env.HOME || process.env.USERPROFILE || "",
+        ".pi",
+        "agent",
+      );
+    const hostAuthFile = join(hostAgentDir, "auth.json");
+    if (!existsSync(hostAuthFile)) {
+      log.debug({ sessionId, hostAuthFile }, "no host auth.json found, skipping");
+      return;
+    }
+
+    const sandboxAgentDir = join(this.sessionDataDir, sessionId, "agent");
+    mkdirSync(sandboxAgentDir, { recursive: true });
+    const destAuthFile = join(sandboxAgentDir, "auth.json");
+
+    try {
+      copyFileSync(hostAuthFile, destAuthFile);
+      log.debug({ sessionId }, "copied host auth.json to introspection sandbox");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn({ sessionId, err: message }, "failed to copy host auth.json");
     }
   }
 

--- a/server/relay/src/services/secrets.service.ts
+++ b/server/relay/src/services/secrets.service.ts
@@ -339,7 +339,7 @@ export class SecretsService {
    * For other providers, all secrets go into direct env.
    */
   async getSecretMaterial(
-    provider: "docker" | "cloudflare" | "gondolin" | "mock",
+    provider: "docker" | "cloudflare" | "gondolin" | "mock" | "local",
   ): Promise<ProviderSecretMaterial> {
     const rows = await this.db
       .select()

--- a/server/relay/src/services/session.service.test.ts
+++ b/server/relay/src/services/session.service.test.ts
@@ -47,10 +47,11 @@ describe("SessionService", () => {
       expect(session.branchName).toBe("session-xyz");
     });
 
-    it("throws if code mode without repoId", () => {
-      expect(() => {
-        service.create({ mode: "code" });
-      }).toThrow("repoId is required for code mode sessions");
+    it("allows code mode without repoId when route validation already handled it", () => {
+      const session = service.create({ mode: "code" });
+      expect(session.mode).toBe("code");
+      expect(session.repoId).toBeNull();
+      expect(session.repoPath).toBeNull();
     });
 
     it("stores model preferences", () => {

--- a/server/relay/src/services/session.service.ts
+++ b/server/relay/src/services/session.service.ts
@@ -49,13 +49,9 @@ export class SessionService {
 
   /**
    * Create a new session.
-   * Code mode requires repoId.
+   * Route-level validation decides whether repoId or repoPath is required.
    */
   create(params: CreateSessionParams): SessionRecord {
-    if (params.mode === "code" && !params.repoId) {
-      throw new Error("repoId is required for code mode sessions");
-    }
-
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 

--- a/server/relay/src/test-helpers.ts
+++ b/server/relay/src/test-helpers.ts
@@ -87,6 +87,9 @@ export function createTestSandboxManager(
       gondolin: {
         sessionDataDir: "/tmp/pi-test-sessions",
       },
+      local: {
+        sessionDataDir: "/tmp/pi-test-sessions",
+      },
     },
     svc,
   );

--- a/server/relay/src/ws/handler.test.ts
+++ b/server/relay/src/ws/handler.test.ts
@@ -34,6 +34,9 @@ describe("WebSocket Handler", () => {
           gondolin: {
             sessionDataDir: "/tmp/pi-test-sessions",
           },
+          local: {
+            sessionDataDir: "/tmp/pi-test-sessions",
+          },
         },
         secretsService,
       ),

--- a/server/relay/src/ws/terminal.ts
+++ b/server/relay/src/ws/terminal.ts
@@ -80,7 +80,11 @@ export function createTerminalHandler(
             : undefined;
 
           const handle = await sandboxManager.getHandleByType(
-            session.sandboxProvider as "docker" | "gondolin" | "cloudflare",
+            session.sandboxProvider as
+              | "docker"
+              | "gondolin"
+              | "cloudflare"
+              | "local",
             session.sandboxProviderId,
             envConfig,
           );


### PR DESCRIPTION
Adds a `local` sandbox provider that runs pi agent sessions directly on the host machine as child processes, without requiring Docker, Cloudflare, or Gondolin VMs.

### What

- **New provider: `local`** (`server/relay/src/sandbox/local.ts`) - Spawns `pi --mode rpc --continue` as a local child process with isolated session directories (agent config, git, workspace). Supports attach (stdin/stdout JSON-RPC), exec, and PTY via `node-pty`.
- **Host auth forwarding** - Copies the host's `auth.json` into each sandbox's agent dir so OAuth-gated providers (e.g. Anthropic) work without re-authentication.
- **Workspace path support** - Local sessions accept a filesystem path instead of a GitHub repo. The `repoId` field is reinterpreted as a local directory path for local environments, validated at the route level.
- **Model introspection fallback** - No longer Gondolin-only. Tries all configured environments in priority order (`local > gondolin > docker > cloudflare`), falling back on failure. Timeout increased to 30s.
- **Dashboard UI** - New "Local" sandbox type option in environment config. Code session creation shows a local path input instead of the GitHub repo selector when a local environment is selected. Environment selector is now visible in both chat and code modes.

### Changes across layers

- **DB schema** - `sandboxType` and `sandboxProvider` enums extended with `"local"`
- **Sandbox manager** - Provider instantiation, secret resolution, and type unions updated
- **Routes** - Sessions, environments, settings, and models routes all handle the new type
- **Git config** - `safe.directory` is now configurable (not hardcoded to `/workspace`)
- **Dashboard** - API types, environment dialog, session creation, terminal WebSocket URL handling, and client ID generation updated
- **Tests** - 3 new session route tests for local workspace handling; existing fixtures updated

### New dependency

- `node-pty` for terminal/PTY support in local sandboxes